### PR TITLE
require admin approval for new accounts (setting)

### DIFF
--- a/pandahub/api/internal/models.py
+++ b/pandahub/api/internal/models.py
@@ -1,9 +1,11 @@
 from fastapi_users import models
 from fastapi_users.authentication.strategy.db import BaseAccessToken
 
+from pandahub.api.internal.settings import REGISTRATION_ADMIN_APPROVAL
+
 
 class User(models.BaseUser):
-    pass
+    is_active: bool = not REGISTRATION_ADMIN_APPROVAL
 
 
 class UserCreate(models.BaseUserCreate):

--- a/pandahub/api/internal/settings.py
+++ b/pandahub/api/internal/settings.py
@@ -31,5 +31,6 @@ EMAIL_VERIFY_URL = os.getenv("EMAIL_VERIFY_URL") or ""
 SECRET = os.getenv("SECRET")
 
 REGISTRATION_ENABLED = settings_bool("REGISTRATION_ENABLED", default=True)
+REGISTRATION_ADMIN_APPROVAL = settings_bool("REGISTRATION_ADMIN_APPROVAL", default=False)
 
 DATATYPES_MODULE = os.getenv("DATATYPES_MODULE") or "pandahub.lib.datatypes"


### PR DESCRIPTION
`REGISTRATION_ADMIN_APPROVAL = true` sets newly registered accounts to be inactive, requiring a super user to patch `is_active` before the account can be used.

 To catch this in client code just check the value of `is_active` in the response from auth/register.