### PR TITLE
Optimize RAM usage when writing net to db

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -986,7 +986,7 @@ class PandaHub:
             obj = json_to_object(document["object"])
             setattr(obj, parameter, value)
             db[collection].find_one_and_update(
-                {**filter, **self.base_variant_filter}, {"$set": {"object._object": obj.to_json()}}
+                {**element_filter, **self.base_variant_filter}, {"$set": {"object._object": obj.to_json()}}
             )
         else:
             variant = int(variant)

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -20,7 +20,7 @@ import pandapower as pp
 import pandapower.io_utils as io_pp
 from pandahub.api.internal import settings
 from pandahub.lib.database_toolbox import create_timeseries_document, convert_timeseries_to_subdocuments, \
-    convert_dataframes_to_dicts, json_to_object
+    convert_element_to_dict, json_to_object, serialize_object_data, get_dtypes
 from pandahub.lib.database_toolbox import decompress_timeseries_data, convert_geojsons
 
 logger = logging.getLogger(__name__)
@@ -320,7 +320,6 @@ class PandaHub:
         return self.active_project.get("version", "0.2.2")
 
     def upgrade_project_to_latest_version(self):
-        from pandapower.io_utils import PPJSONEncoder
         # TODO check that user has right to write user_management
         # TODO these operations should be encapsulated in a transaction in order to avoid
         #      inconsistent Database states in case of occuring errors
@@ -349,7 +348,7 @@ class PandaHub:
                     try:
                         json.dumps(dat)
                     except:
-                        dat = f"serialized_{json.dumps(data, cls=PPJSONEncoder)}"
+                        dat = f"serialized_{json.dumps(data, cls=io_pp.PPJSONEncoder)}"
                     data[key] = dat
 
                 db["_networks"].find_one_and_update({"_id":d["_id"]},
@@ -712,15 +711,31 @@ class PandaHub:
         max_id_network = db["_networks"].find_one(sort=[("_id", -1)])
         _id = 0 if max_id_network is None else max_id_network["_id"] + 1
 
-        dfs, data, types = convert_dataframes_to_dicts(net, _id,
-                                                       version.parse(self.get_project_version()),
-                                                       self._datatypes)
-        self._write_net_collections_to_db(db, dfs)
+        data = {}
+        dtypes = {}
+        version_ = version.parse(self.get_project_version())
+        for element, element_data in net.items():
+            if element.startswith("_") or element.startswith("res"):
+                continue
+            if isinstance(element_data, pd.core.frame.DataFrame):
+                # create type lookup
+                dtypes[element] = get_dtypes(element_data, self._datatypes.get(element))
+                if element_data.empty:
+                    continue
+                # convert pandapower dataframe object to dict and save to db
+                element_data = convert_element_to_dict(element_data.copy(deep=True), _id, self._datatypes.get(element))
+                self._write_element_to_db(db, element, element_data)
 
+            else:
+                element_data = serialize_object_data(element, element_data, version_)
+                if data:
+                    data[element] = element_data
+
+        # write network metadata
         net_dict = {"_id": _id,
                     "name": name,
                     "sector": sector,
-                    "dtypes": types,
+                    "dtypes": dtypes,
                     "data": data}
 
         if metadata is not None:
@@ -728,9 +743,12 @@ class PandaHub:
         db["_networks"].insert_one(net_dict)
 
     def _write_net_collections_to_db(self, db, collections):
-        existing_collections = set(db.list_collection_names())
+        for element, element_data in collections.items():
+            self._write_element_to_db(db, element, element_data)
 
-        def add_index(element, df_dict):
+    def _write_element_to_db(self, db, element, element_data):
+        existing_collections = set(db.list_collection_names())
+        def add_index(element):
             columns = {"bus": ["net_id", "index"],
                        "line": ["net_id", "index", "from_bus", "to_bus"],
                        "trafo": ["net_id", "index", "hv_bus", "lv_bus"],
@@ -744,16 +762,16 @@ class PandaHub:
                 logger.info(f"creating index on '{c}' in collection '{element}'")
                 db[self._collection_name_of_element(element)].create_index([(c, DESCENDING)])
 
-        for element, df_dict in collections.items():
-            if len(df_dict) > 0:
-                collection_name = self._collection_name_of_element(element)
-                try:
-                    db[collection_name].insert_many(df_dict, ordered=False)
-                    if collection_name not in existing_collections:
-                        add_index(element, df_dict)
-                except:
-                    traceback.print_exc()
-                    print(f"\nFAILED TO WRITE TABLE '{element}' TO DATABASE! (details above)")
+
+        collection_name = self._collection_name_of_element(element)
+        if len(element_data) > 0:
+            try:
+                db[collection_name].insert_many(element_data, ordered=False)
+                if collection_name not in existing_collections:
+                    add_index(element)
+            except:
+                traceback.print_exc()
+                print(f"\nFAILED TO WRITE TABLE '{element}' TO DATABASE! (details above)")
 
     def delete_net_from_db(self, name):
         self.check_permission("write")

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -728,7 +728,7 @@ class PandaHub:
 
             else:
                 element_data = serialize_object_data(element, element_data, version_)
-                if data:
+                if element_data:
                     data[element] = element_data
 
         # write network metadata

--- a/pandahub/lib/database_toolbox.py
+++ b/pandahub/lib/database_toolbox.py
@@ -197,7 +197,41 @@ def create_timeseries_document(timeseries,
 
     return document
 
-def convert_dataframes_to_dicts(net, _id, version_,datatypes=None):
+def convert_element_to_dict(element_data, net_id, default_dtypes=None):
+    '''
+    Converts a pandapower pandas.DataFrame element into dictonary, casting columns to default dtypes.
+    * Columns of type Object are serialized to json
+    * Columns named "geo" or "*_geo" containing strings are parsed into dicts
+    * net_id and index (from element_data df index) are added as values
+
+    Parameters
+    ----------
+    element_data: pandas.DataFrame
+        pandapower element table to convert to dict
+    net_id: int
+        Network id
+    default_dtypes: dict
+        Default dtypes for columns in element_data
+
+    Returns
+    -------
+    dict
+        Record-orientated dict representation of element_data
+
+    '''
+    if default_dtypes is not None:
+        for column in element_data.columns:
+            if column in default_dtypes:
+                element_data[column] = element_data[column].astype(default_dtypes[column], errors="ignore")
+
+    if "object" in element_data.columns:
+        element_data["object"] = element_data["object"].apply(object_to_json)
+    element_data["index"] = element_data.index
+    element_data["net_id"] = net_id
+    load_geojsons(element_data)
+    return element_data.to_dict(orient="records")
+
+def convert_dataframes_to_dicts(net, net_id, version_, datatypes=None):
     if datatypes is None:
         datatypes = getattr(importlib.import_module(settings.DATATYPES_MODULE), "datatypes")
 
@@ -208,57 +242,84 @@ def convert_dataframes_to_dicts(net, _id, version_,datatypes=None):
         if key.startswith("_") or key.startswith("res"):
             continue
         if isinstance(data, pd.core.frame.DataFrame):
-
             # ------------
             # create type lookup
-
-            types[key] = dict()
-            default_dtypes = datatypes.get(key)
-            if default_dtypes is not None:
-                types[key].update({key: dtype.__name__ for key, dtype in default_dtypes.items()})
-            types[key].update(
-                {
-                    column: str(dtype) for column, dtype in net[key].dtypes.items()
-                    if column not in types[key]
-                }
-            )
+            types[key] = get_dtypes(key, data, datatypes.get(key))
             if data.empty:
                 continue
-
             # ------------
             # convert pandapower objects in dataframes to dict
-
-            df = net[key].copy(deep=True)
-
-            # ------------
-            # cast all columns with their default datatype
-
-            if default_dtypes is not None:
-                for column in df.columns:
-                    if column in default_dtypes:
-                        df[column] = df[column].astype(default_dtypes[column], errors="ignore")
-
-            if "object" in df.columns:
-                df["object"] = df["object"].apply(object_to_json)
-            df["index"] = df.index
-            df["net_id"] = _id
-            load_geojsons(df)
-            dataframes[key] = df.to_dict(orient="records")
+            dataframes[key] = convert_element_to_dict(net[key].copy(deep=True), net_id, datatypes.get(key))
         else:
-            if version_ <= version.parse("0.2.3"):
-                try:
-                    data = json.dumps(data, cls=PPJSONEncoder)
-                except:
-                    print("Data in net[{}] is not JSON serializable and was therefore omitted on import".format(key))
-                else:
-                    other_parameters[key] = data
-            else:
-                try:
-                    json.dumps(data)
-                except:
-                    data = f"serialized_{json.dumps(data, cls=PPJSONEncoder)}"
+            data = serialize_object_data(key, data, version_)
+            if data:
                 other_parameters[key] = data
+
     return dataframes, other_parameters, types
+
+def serialize_object_data(element, element_data, version_):
+    '''
+    Serialize a pandapower element which is not of type pandas.DataFrame into json.
+
+    Parameters
+    ----------
+    element: str
+        Name of the pandapower element
+    element_data: object
+        pandapower element data
+    version_:
+        pandahub version to target for serialization
+
+    Returns
+    -------
+    json
+        A json representation of the pandapower element
+    '''
+    if version_ <= version.parse("0.2.3"):
+        try:
+            element_data = json.dumps(element_data, cls=PPJSONEncoder)
+        except:
+            print(
+                "Data in net[{}] is not JSON serializable and was therefore omitted on import".format(element))
+        else:
+            return element_data
+    else:
+        try:
+            json.dumps(element_data)
+        except:
+            element_data = f"serialized_{json.dumps(element_data, cls=PPJSONEncoder)}"
+        return element_data
+
+
+def get_dtypes(element_data, default_dtypes):
+    '''
+    Construct data types from a pandas.DataFrame, with given defaults taking precedence.
+
+    Parameters
+    ----------
+    element_data: pandas.DataFrame
+        Input dataframe
+    default_dtypes: dict
+        Default datatypes definition
+
+    Returns
+    -------
+    dict
+        Datatypes for all columns present in element_data. Column type is taken from default_dtypes if defined,
+        otherwise directly from element_data
+
+    '''
+    types = {}
+    if default_dtypes is not None:
+        types.update({key: dtype.__name__ for key, dtype in default_dtypes.items()})
+    types.update(
+        {
+            column: str(dtype) for column, dtype in element_data.dtypes.items()
+            if column not in types
+        }
+    )
+    return types
+
 
 def load_geojsons(df):
     for column in df.columns:


### PR DESCRIPTION
When a network is written to the database, the columns of all database tables are first cast to appropriate types (in a deep copy to retain the original df's), converted to dict records, and processed further to make sure they cleanly serialize to json.

The current implementation pipes the complete network through each of these steps, then writes all element tables to the database. With large networks, RAM usage spikes when saving them to the database (> 30GB in one case).

This PR chunks the serialization and writing of networks by element, which allows the memory taken by each preprocessed version of the element table to be freed after each write.

Impact on performance should be negligible, but exceptions raised during serializations previously resulted in nothing being written to the database, while now some successfully serialized elements might have been written to the database when the exception occurs during processing of a later element. 