### PR TITLE
allow passing mongodb user/pw explicitly

### DIFF
--- a/pandahub/api/internal/db.py
+++ b/pandahub/api/internal/db.py
@@ -8,7 +8,8 @@ from pandahub.api.internal import settings
 from pandahub.api.internal.models import AccessToken, UserDB
 
 client = motor.motor_asyncio.AsyncIOMotorClient(
-    settings.MONGODB_URL, uuidRepresentation="standard"
+    host=settings.MONGODB_URL, username=settings.MONGODB_USER, password=settings.MONGODB_PASSWORD,
+    uuidRepresentation="standard"
 )
 
 client.get_io_loop = asyncio.get_event_loop

--- a/pandahub/api/internal/db.py
+++ b/pandahub/api/internal/db.py
@@ -7,10 +7,11 @@ from fastapi_users_db_mongodb.access_token import MongoDBAccessTokenDatabase
 from pandahub.api.internal import settings
 from pandahub.api.internal.models import AccessToken, UserDB
 
-client = motor.motor_asyncio.AsyncIOMotorClient(
-    host=settings.MONGODB_URL, username=settings.MONGODB_USER, password=settings.MONGODB_PASSWORD,
-    uuidRepresentation="standard"
-)
+mongo_client_args = {"host": settings.MONGODB_URL, "uuidRepresentation": "standard", "connect": False}
+if settings.MONGODB_USER:
+    mongo_client_args |= {"username": settings.MONGODB_USER, "password": settings.MONGODB_PASSWORD}
+
+client = motor.motor_asyncio.AsyncIOMotorClient(**mongo_client_args)
 
 client.get_io_loop = asyncio.get_event_loop
 

--- a/pandahub/api/internal/settings.py
+++ b/pandahub/api/internal/settings.py
@@ -11,11 +11,25 @@ def settings_bool(var_name, default=None):
         return False
     return False
 
+def get_secret(key, default=None):
+    secret = os.getenv(key, default)
+    if secret and os.path.isfile(secret):
+        with open(secret) as f:
+            secret = f.read()
+    return secret
+
 # load variables from .env to environment variables
 load_dotenv()
 
-MONGODB_URL = os.getenv("MONGODB_URL") or "mongodb://localhost:27017"
-MONGODB_URL_GLOBAL_DATABASE = os.getenv("MONGODB_URL_GLOBAL_DATABASE") or None
+MONGODB_URL = get_secret("MONGODB_URL") or "mongodb://localhost:27017"
+MONGODB_USER = get_secret("MONGODB_USER") or None
+MONGODB_PASSWORD = get_secret("MONGODB_PASSWORD") or None
+
+MONGODB_GLOBAL_DATABASE_URL = get_secret("MONGODB_GLOBAL_DATABASE_URL") or None
+MONGODB_GLOBAL_DATABASE_USER = get_secret("MONGODB_GLOBAL_DATABASE_USER") or None
+MONGODB_GLOBAL_DATABASE_PASSWORD = get_secret("MONGODB_GLOBAL_DATABASE_PASSWORD") or None
+if not MONGODB_GLOBAL_DATABASE_URL:
+    MONGODB_GLOBAL_DATABASE_URL = os.getenv("MONGODB_URL_GLOBAL_DATABASE") or None
 
 EMAIL_VERIFICATION_REQUIRED = settings_bool("EMAIL_VERIFICATION_REQUIRED")
 
@@ -28,7 +42,7 @@ MAIL_SSL = os.getenv("MAIL_SSL") or False
 
 PASSWORD_RESET_URL = os.getenv("PASSWORD_RESET_URL") or ""
 EMAIL_VERIFY_URL = os.getenv("EMAIL_VERIFY_URL") or ""
-SECRET = os.getenv("SECRET")
+SECRET = get_secret("SECRET") or None
 
 REGISTRATION_ENABLED = settings_bool("REGISTRATION_ENABLED", default=True)
 REGISTRATION_ADMIN_APPROVAL = settings_bool("REGISTRATION_ADMIN_APPROVAL", default=False)

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -56,12 +56,10 @@ class PandaHub:
     # Initialization
     # -------------------------
 
-    def __init__(self, connection_url=None, check_server_available=False, user_id=None):
-        if connection_url is None:
-            connection_url = settings.MONGODB_URL
-        if not connection_url.startswith('mongodb://'):
-            raise PandaHubError("Connection URL needs to point to a mongodb instance: 'mongodb://..'")
-        self.mongo_client = MongoClient(host=connection_url, uuidRepresentation="standard", connect=False)
+    def __init__(self, connection_url=settings.MONGODB_URL, connection_user = settings.MONGODB_USER,
+                 connection_password=settings.MONGODB_PASSWORD, check_server_available=False, user_id=None):
+        self.mongo_client = MongoClient(host=connection_url, username=connection_user, password=connection_password,
+                                        uuidRepresentation="standard", connect=False)
         self.mongo_client_global_db = None
         self.active_project = None
         self.user_id = user_id
@@ -307,9 +305,11 @@ class PandaHub:
         return self.mongo_client[str(self.active_project["_id"])]
 
     def _get_global_database(self):
-        if self.mongo_client_global_db is None and not settings.MONGODB_URL_GLOBAL_DATABASE is None:
+        if self.mongo_client_global_db is None and settings.MONGODB_GLOBAL_DATABASE_URL is not None:
             self.mongo_client_global_db = MongoClient(
-                host=settings.MONGODB_URL_GLOBAL_DATABASE, uuidRepresentation="standard"
+                host=settings.MONGODB_GLOBAL_DATABASE_URL, username=settings.MONGODB_GLOBAL_DATABASE_USER,
+                password=settings.MONGODB_GLOBAL_DATABASE_PASSWORD,
+                uuidRepresentation="standard"
             )
         if self.mongo_client_global_db is None:
             return self.mongo_client["global_data"]

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -58,8 +58,11 @@ class PandaHub:
 
     def __init__(self, connection_url=settings.MONGODB_URL, connection_user = settings.MONGODB_USER,
                  connection_password=settings.MONGODB_PASSWORD, check_server_available=False, user_id=None):
-        self.mongo_client = MongoClient(host=connection_url, username=connection_user, password=connection_password,
-                                        uuidRepresentation="standard", connect=False)
+
+        mongo_client_args = {"host": connection_url, "uuidRepresentation": "standard", "connect":False}
+        if connection_user:
+            mongo_client_args |= {"username": connection_user, "password": connection_password}
+        self.mongo_client = MongoClient(**mongo_client_args)
         self.mongo_client_global_db = None
         self.active_project = None
         self.user_id = user_id


### PR DESCRIPTION
PandaHub() gains `username` and `password` arguments passed through to MongoClient (alongside the existing `connection_url`, which is passed as `host`), allowing host and authentication parameters to be provided separately.

Docker secrets (reading the value from a file instead of directly from the environment) are supported for the following variables:
SECRET
MONGODB_URL
MONGODB_USER
MONGODB_PASSWORD
MONGODB_GLOBAL_DATABASE_URL
MONGODB_GLOBAL_DATABASE_USER
MONGODB_GLOBAL_DATABASE_PASSWORD
