### PR TITLE
Cosmos-DB compatability

### DIFF
--- a/pandahub/api/internal/db.py
+++ b/pandahub/api/internal/db.py
@@ -43,7 +43,7 @@ class MongoDBUserDatabaseCosmos(MongoDBUserDatabase):
 
     async def _initialize(self):
         if not self.initialized:
-            if "email_1" not in self.collection.index_information():
+            if "email_1" not in await self.collection.index_information():
                 await self.collection.create_index("id", unique=True)
                 await self.collection.create_index("email", unique=True)
         self.initialized = True

--- a/pandahub/api/internal/db.py
+++ b/pandahub/api/internal/db.py
@@ -21,8 +21,29 @@ access_tokens_collection = db["access_tokens"]
 
 
 async def get_user_db():
-    yield MongoDBUserDatabase(UserDB, collection)
+    if settings.COSMOSDB_COMPAT:
+        yield MongoDBUserDatabaseCosmos(UserDB, collection)
+    else:
+        yield MongoDBUserDatabase(UserDB, collection)
 
 
 async def get_access_token_db():
     yield MongoDBAccessTokenDatabase(AccessToken, access_tokens_collection)
+
+class MongoDBUserDatabaseCosmos(MongoDBUserDatabase):
+    from typing import Optional
+    from fastapi_users.models import UD
+    async def get_by_email(self, email: str) -> Optional[UD]:
+        await self._initialize()
+
+        user = await self.collection.find_one(
+            {"email": email}
+        )
+        return self.user_db_model(**user) if user else None
+
+    async def _initialize(self):
+        if not self.initialized:
+            if "email_1" not in self.collection.index_information():
+                await self.collection.create_index("id", unique=True)
+                await self.collection.create_index("email", unique=True)
+        self.initialized = True

--- a/pandahub/api/internal/settings.py
+++ b/pandahub/api/internal/settings.py
@@ -48,3 +48,4 @@ REGISTRATION_ENABLED = settings_bool("REGISTRATION_ENABLED", default=True)
 REGISTRATION_ADMIN_APPROVAL = settings_bool("REGISTRATION_ADMIN_APPROVAL", default=False)
 
 DATATYPES_MODULE = os.getenv("DATATYPES_MODULE") or "pandahub.lib.datatypes"
+COSMOSDB_COMPAT = settings_bool("COSMOSDB_COMPAT", default=False)


### PR DESCRIPTION
Azure Cosmos DB for MongoDB neither supports [creating unique index on non-empty collections](https://learn.microsoft.com/en-us/azure/cosmos-db/mongodb/indexing#limitations-1) nor [collation](https://learn.microsoft.com/en-us/answers/questions/1304496/how-can-i-define-a-collation-when-creating-an-inde), which leads to exceptions in fastapi-users.

Introduce a setting COSMOSDB_COMPAT which, when set, replaces MongoDBUserDatabase with a subclass with the incompatible function calls patched out:
* only set indexes if they do not exist on the collection (so they are set only once, before documents are inserted)
* do not use collation when storing/querying the email field

Skipping the collation means that email addressess (usernames) are not case-insensitive anymore - i.e. my@user.de and My@user.de are treated as different accounts.