### PR TITLE
Fix: Consider elements with `var_type = NaN` in base variant

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -70,7 +70,8 @@ class PandaHub:
         self.base_variant_filter = {
             "$or": [
                 {"var_type": {"$exists": False}},
-                {"var_type": "base"}
+                {"var_type": "base"},
+                {"var_type": np.nan},
             ]
         }
         if check_server_available:


### PR DESCRIPTION
When selecting elements from the MongoDB, the query is limited to the selected variant(s) or the base variant. The base variant filter used to select only those records for which `var_type == "base"` or those which do not contain a `var_type` column at all. This led to inconsistent results of `get_net` for nets where some records to have a `var_type` column and some do not:
When the net is fetched the first time, all elements are present. Pandas will insert `NaN` as the variant type for rows in which `var_type` is not present. If the user then writes the entire net (or collection) back to the database, those `NaN`s will be inserted into the records that previously did not contain `var_type`. On subsequent calls of `get_net`, those records thus do not fulfill the `base_variant_filter` anymore (because `var_type` is present and not `"base"` but `NaN`). Fix this behaviour by adapting `base_variant_filter` to also include elements for which `var_type == NaN`.