### PR TITLE
Fix: 'TypeError' in ph.get_net_value_from_db

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -883,22 +883,23 @@ class PandaHub:
         db = self._get_project_database()
         _id = self._get_id_from_name(net_name, db)
         collection = self._collection_name_of_element(element)
+        dtypes = self._datatypes.get(element)
+
         variant_filter = self.get_variant_filter(variant)
-        elements = list(db[collection].find({"index": element_index, "net_id": _id, **variant_filter}))
-        if len(elements) == 1:
-            element = elements[0]
+        documents = list(db[collection].find({"index": element_index, "net_id": _id, **variant_filter}))
+        if len(documents) == 1:
+            document = documents[0]
         else:
-            if len(elements) == 0:
+            if len(documents) == 0:
                 raise PandaHubError("Element doesn't exist", 404)
             else:
                 raise PandaHubError("Multiple elements found", 404)
-        dtypes = self._datatypes.get(element)
-        if parameter not in element:
+        if parameter not in document:
             raise PandaHubError("Parameter doesn't exist", 404)
         if dtypes is not None and parameter in dtypes:
-            return dtypes[parameter](element[parameter])
+            return dtypes[parameter](document[parameter])
         else:
-            return element[parameter]
+            return document[parameter]
 
     def delete_net_element(self, net_id, element, element_index, variant=None, project_id=None):
         if variant is not None:


### PR DESCRIPTION
The `PandaHub.get_net_value_from_db` method used the variable name "element" once for the type of element for which to look up a specified value ("load", "sgen", "bus", "trafo", etc.) and once for the MongoDB document retrieved from the database. This led to a TypeError when calling the method, as "element" was used to determine `dtypes` in line 895 *after* it went from being the element type to the db document. Fix this by determining dtypes prior to the DB query. Furthermore, rename the collection retrieved from the DB to "documents" and "document" for clarity, which is consistent with the implementation of `ph.set_net_value_in_db`.