### PR TITLE
Refactor functions for element creation and deletion

### DIFF
--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -44,13 +44,15 @@ def write_network_to_db(data: WriteNetwork, ph=Depends(pandahub)):
 
 
 # -------------------------
-# Element handling
+# Element CRUD
 # -------------------------
 
-class GetNetValueModel(BaseModel):
+class BaseCRUDModel(BaseModel):
     project_id: str
     net_name: str
-    element: str
+    element_type: str
+
+class GetNetValueModel(BaseCRUDModel):
     element_index: int
     parameter: str
 
@@ -58,10 +60,7 @@ class GetNetValueModel(BaseModel):
 def get_net_value_from_db(data: GetNetValueModel, ph=Depends(pandahub)):
     return ph.get_net_value_from_db(**data.dict())
 
-class SetNetValueModel(BaseModel):
-    project_id: str
-    net_name: str
-    element: str
+class SetNetValueModel(BaseCRUDModel):
     element_index: int
     parameter: str
     value: Any
@@ -70,33 +69,45 @@ class SetNetValueModel(BaseModel):
 def set_net_value_in_db(data: SetNetValueModel, ph=Depends(pandahub)):
     return ph.set_net_value_in_db(**data.dict())
 
-class CreateElementModel(BaseModel):
-    project_id: str
-    net_name: str
-    element: str
+class CreateElementModel(BaseCRUDModel):
     element_index: int
-    data: dict
+    element_data: dict
+
+@router.post("/create_element")
+def create_element_in_db(data: CreateElementModel, ph=Depends(pandahub)):
+    return ph.create_element(**data.dict())
+
+class CreateElementsModel(BaseCRUDModel):
+    elements_data: list[dict[str,Any]]
+
+@router.post("/create_elements")
+def create_elements_in_db(data: CreateElementsModel, ph=Depends(pandahub)):
+    return ph.create_elements(**data.dict())
+
+class DeleteElementModel(BaseCRUDModel):
+    element_index: int
+
+@router.post("/delete_element")
+def delete_net_element(data: DeleteElementModel, ph=Depends(pandahub)):
+    return ph.delete_element(**data.dict())
+
+class DeleteElementsModel(BaseCRUDModel):
+    element_indexes: list[int]
+
+@router.post("/delete_elements")
+def delete_net_elements(data: DeleteElementsModel, ph=Depends(pandahub)):
+    return ph.delete_elements(**data.dict())
+
+### deprecated routes
 
 @router.post("/create_element_in_db")
 def create_element_in_db(data: CreateElementModel, ph=Depends(pandahub)):
-    return ph.create_element_in_db(**data.dict())
-
-class CreateElementsModel(BaseModel):
-    project_id: str
-    net_name: str
-    element_type: str
-    elements_data: list
+    return ph.create_element(**data.dict())
 
 @router.post("/create_elements_in_db")
 def create_elements_in_db(data: CreateElementsModel, ph=Depends(pandahub)):
-    return ph.create_elements_in_db(**data.dict())
-
-class DeleteElementModel(BaseModel):
-    project_id: str
-    net_name: str
-    element: str
-    element_index: int
+    return ph.create_elements(**data.dict())
 
 @router.post("/delete_net_element")
 def delete_net_element(data: DeleteElementModel, ph=Depends(pandahub)):
-    return ph.delete_net_element(**data.dict())
+    return ph.delete_element(**data.dict())

--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -49,7 +49,7 @@ def write_network_to_db(data: WriteNetwork, ph=Depends(pandahub)):
 
 class BaseCRUDModel(BaseModel):
     project_id: str
-    net_name: str
+    net: str
     element_type: str
 
 class GetNetValueModel(BaseCRUDModel):
@@ -100,14 +100,27 @@ def delete_net_elements(data: DeleteElementsModel, ph=Depends(pandahub)):
 
 ### deprecated routes
 
+class CreateElementModelDeprecated(BaseModel):
+    project_id: str
+    net_name: str
+    element: str
+    element_index: int
+    data: dict
+
 @router.post("/create_element_in_db")
-def create_element_in_db(data: CreateElementModel, ph=Depends(pandahub)):
-    return ph.create_element(**data.dict())
+def create_element_in_db(data: CreateElementModelDeprecated, ph=Depends(pandahub)):
+    return ph.create_element_in_db(**data.dict())
 
 @router.post("/create_elements_in_db")
 def create_elements_in_db(data: CreateElementsModel, ph=Depends(pandahub)):
-    return ph.create_elements(**data.dict())
+    return ph.create_elements_in_db(**data.dict())
+
+class DeleteElementModelDeprecated(BaseModel):
+    project_id: str
+    net_name: str
+    element: str
+    element_index: int
 
 @router.post("/delete_net_element")
-def delete_net_element(data: DeleteElementModel, ph=Depends(pandahub)):
-    return ph.delete_element(**data.dict())
+def delete_net_element(data: DeleteElementModelDeprecated, ph=Depends(pandahub)):
+    return ph.delete_net_element(**data.dict())

--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -99,28 +99,15 @@ def delete_net_elements(data: DeleteElementsModel, ph=Depends(pandahub)):
     return ph.delete_elements(**data.dict())
 
 ### deprecated routes
-
-class CreateElementModelDeprecated(BaseModel):
-    project_id: str
-    net_name: str
-    element: str
-    element_index: int
-    data: dict
-
 @router.post("/create_element_in_db")
-def create_element_in_db(data: CreateElementModelDeprecated, ph=Depends(pandahub)):
-    return ph.create_element_in_db(**data.dict())
+def create_element_in_db(*args, **kwargs):
+    raise RuntimeError("create_element_in_db was deprecated - use create_element instead!")
 
 @router.post("/create_elements_in_db")
-def create_elements_in_db(data: CreateElementsModel, ph=Depends(pandahub)):
-    return ph.create_elements_in_db(**data.dict())
+def create_elements_in_db(*args, **kwargs):
+    raise RuntimeError("create_elements_in_db was deprecated - use create_elements instead!")
 
-class DeleteElementModelDeprecated(BaseModel):
-    project_id: str
-    net_name: str
-    element: str
-    element_index: int
 
 @router.post("/delete_net_element")
-def delete_net_element(data: DeleteElementModelDeprecated, ph=Depends(pandahub)):
-    return ph.delete_net_element(**data.dict())
+def delete_net_element(*args, **kwargs):
+    raise RuntimeError("delete_net_element was deprecated - use delete_element instead!")

--- a/pandahub/client/PandaHubClient.py
+++ b/pandahub/client/PandaHubClient.py
@@ -94,18 +94,15 @@ class PandaHubClient:
 
     ### deprecated functions
 
-    def create_element_in_db(self, net_name, element, element_index, data):
-        warnings.warn("create_element_in_db was renamed - use create_element instead!")
-        return self._post("/net/create_element", json=locals())
+    def create_element_in_db(self, *args, **kwargs):
+        raise RuntimeError("create_element_in_db was deprecated - use create_element instead!")
 
-    def create_elements_in_db(self, net_name, element_type, elements_data):
-        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead! "
+    def create_elements_in_db(self, *args, **kwargs):
+        raise RuntimeError("ph.create_elements_in_db was deprecated - use ph.create_elements instead! "
                       "Watch out for changed order of project_id and variant args")
-        return self._post("/net/create_elements", json=locals())
 
-    def delete_net_element(self, net_name, element, element_index):
-        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead!")
-        return self._post("/net/delete_element", json=locals())
+    def delete_net_element(self, *args, **kwargs):
+        raise RuntimeError("ph.delete_net_element was deprecated - use ph.delete_element instead!")
 
 
     ### TIMESERIES

--- a/pandahub/client/PandaHubClient.py
+++ b/pandahub/client/PandaHubClient.py
@@ -79,31 +79,32 @@ class PandaHubClient:
     def set_net_value_in_db(self, net_name, element_type, element_index, parameter, value):
         return self._post("/net/set_net_value_in_db", json=locals())
 
-    def create_element(self, net_name, element_type, element_index, element_data):
+    def create_element(self, net, element_type, element_index, element_data):
         return self._post("/net/create_element", json=locals())
 
-    def create_elements(self, net_name, element_type, elements_data):
+    def create_elements(self, net, element_type, elements_data):
         return self._post("/net/create_elements", json=locals())
 
-    def delete_element(self, net_name, element_type, element_index):
+    def delete_element(self, net, element_type, element_index):
         return self._post("/net/delete_element", json=locals())
 
-    def delete_elements(self, net_name, element_type, element_index):
+    def delete_elements(self, net, element_type, element_index):
         return self._post("/net/delete_elements", json=locals())
 
 
     ### deprecated functions
 
-    def create_element_in_db(self, net_name, element_type, element_index, data):
-        warnings.warn("ph.create_element_in_db was renamed - use ph.create_element instead")
+    def create_element_in_db(self, net_name, element, element_index, data):
+        warnings.warn("create_element_in_db was renamed - use create_element instead!")
         return self._post("/net/create_element", json=locals())
 
     def create_elements_in_db(self, net_name, element_type, elements_data):
-        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead")
+        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead! "
+                      "Watch out for changed order of project_id and variant args")
         return self._post("/net/create_elements", json=locals())
 
     def delete_net_element(self, net_name, element, element_index):
-        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead")
+        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead!")
         return self._post("/net/delete_element", json=locals())
 
 

--- a/pandahub/client/PandaHubClient.py
+++ b/pandahub/client/PandaHubClient.py
@@ -1,3 +1,5 @@
+import warnings
+
 import requests
 import pandapower as pp
 import pandas as pd
@@ -74,17 +76,35 @@ class PandaHubClient:
     def get_net_value_from_db(self, net_name, element, element_index, parameter):
         return self._post("/net/get_net_value_from_db", json=locals()).json()
 
-    def set_net_value_in_db(self, net_name, element, element_index, parameter, value):
+    def set_net_value_in_db(self, net_name, element_type, element_index, parameter, value):
         return self._post("/net/set_net_value_in_db", json=locals())
 
-    def create_element_in_db(self, net_name, element, element_index, data):
-        return self._post("/net/create_element_in_db", json=locals())
+    def create_element(self, net_name, element_type, element_index, element_data):
+        return self._post("/net/create_element", json=locals())
+
+    def create_elements(self, net_name, element_type, elements_data):
+        return self._post("/net/create_elements", json=locals())
+
+    def delete_element(self, net_name, element_type, element_index):
+        return self._post("/net/delete_element", json=locals())
+
+    def delete_elements(self, net_name, element_type, element_index):
+        return self._post("/net/delete_elements", json=locals())
+
+
+    ### deprecated functions
+
+    def create_element_in_db(self, net_name, element_type, element_index, data):
+        warnings.warn("ph.create_element_in_db was renamed - use ph.create_element instead")
+        return self._post("/net/create_element", json=locals())
 
     def create_elements_in_db(self, net_name, element_type, elements_data):
-        return self._post("/net/create_elements_in_db", json=locals())
+        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead")
+        return self._post("/net/create_elements", json=locals())
 
     def delete_net_element(self, net_name, element, element_index):
-        return self._post("/net/delete_net_element", json=locals())
+        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead")
+        return self._post("/net/delete_element", json=locals())
 
 
     ### TIMESERIES

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -1056,31 +1056,13 @@ class PandaHub:
                 db[collection].update_one({"_id": document["_id"]},
                                           {"$set": {"object._object": obj}})
 
-    def create_element_in_db(self, net, element, element_index, data, variant=None, project_id=None):
-        logger.info(f"Creating element {element} with index {element_index} and variant {variant}, data: {data}")
-        if project_id:
-            self.set_active_project_by_id(project_id)
-        self.check_permission("write")
-        db = self._get_project_database()
-        if type(net) == str:
-            net_id = self._get_id_from_name(net, db)
-        else:
-            net_id = net
+    def create_element_in_db(self, net: Union[int, str], element_type: str, element_index: int, data: dict,
+                             variant=None, project_id=None):
+        return self.create_elements_in_db(net, element_type, [{"index": element_index, **data}],
+                                          project_id, variant)[0]
 
-        element_data = {**data, **{"index": element_index, "net_id": int(net_id)}}
-        if not variant:
-            element_data.update(var_type="base", not_in_var=[])
-        else:
-            element_data.update(var_type="addition", variant=int(variant))
-        self._add_missing_defaults(db, net_id, element, element_data)
-        self._ensure_dtypes(element, element_data)
-        collection = self._collection_name_of_element(element)
-        insert_result = db[collection].insert_one(element_data)
-        element_data["_id"] = insert_result.inserted_id
-        return element_data
-
-    def create_elements_in_db(self, net: Union[int,str], element_type: str, elements_data: list, project_id=None,
-                              variant=None):
+    def create_elements_in_db(self, net: Union[int, str], element_type: str, elements_data: list[dict],
+                              project_id: str = None, variant: int = None):
         if project_id:
             self.set_active_project_by_id(project_id)
         self.check_permission("write")

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-
 import builtins
 import importlib
 import json
 import logging
 import traceback
+import warnings
 from inspect import signature, _empty
 from typing import Optional, Union
 
@@ -913,13 +913,52 @@ class PandaHub:
         else:
             return document[parameter]
 
-    def delete_net_element(self, net, element_type, element_index, variant=None, project_id=None):
-        return self.delete_net_elements(net, element_type, [element_index], variant, project_id)[0]
+    def delete_element(self, net, element_type, element_index, variant=None, project_id=None):
+        """
+        Delete an element from the database.
 
-    def delete_net_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
+        Parameters
+        ----------
+        net: str or int
+            Network to add elements to, either a name or numeric id
+        element_type: str
+            Name of the element type (e.g. bus, line)
+        element_index: int
+            Index of the element to delete
+        project_id: str or None
+            ObjectId (as str) of the project in which the network is stored. Defaults to current active project if None
+        variant: int or None
+            Variant index if elements should be created in a variant
+        Returns
+        -------
+        dict
+            The deleted element as dict with all fields
+        """
+        return self.delete_elements(net, element_type, [element_index], variant, project_id)[0]
+
+    def delete_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
                             variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None) -> list[
         dict]:
+        """
+        Delete multiple elements of the same type from the database.
 
+        Parameters
+        ----------
+        net: str or int
+            Network to add elements to, either a name or numeric id
+        element_type: str
+            Name of the element type (e.g. bus, line)
+        element_indexes: list of int
+            Indexes of the elements to delete
+        project_id: str or None
+            ObjectId (as str) of the project in which the network is stored. Defaults to current active project if None
+        variant: int or None
+            Variant index if elements should be created in a variant
+        Returns
+        -------
+        list
+            A list of deleted elements as dicts with all fields
+        """
         if not isinstance(element_indexes, list):
             raise TypeError("Parameter element_indexes must be a list of ints!")
 
@@ -1080,7 +1119,7 @@ class PandaHub:
         dict
             The created element (element_data with added _id field)
         """
-        return self.create_elements_in_db(net, element_type, [{"index": element_index, **element_data}],
+        return self.create_elements(net, element_type, [{"index": element_index, **element_data}],
                                           project_id, variant)[0]
 
     def create_elements(self, net: Union[int, str], element_type: str, elements_data: list[dict],
@@ -2029,6 +2068,20 @@ class PandaHub:
             "ph.create_elements_in_db was renamed - use ph.create_elements instead"
         )
         return self.create_elements(net, element_type, elements_data, project_id, variant)
+
+    def delete_net_element(self, net, element_type, element_index, variant=None, project_id=None):
+        warnings.warn(
+            "ph.delete_net_element was renamed - use ph.delete_element instead"
+        )
+        return self.delete_element(net, element_type, element_index, variant, project_id)
+
+    def delete_net_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
+                            variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None):
+        warnings.warn(
+            "ph.delete_net_elementS was renamed - use ph.delete_elementS instead"
+        )
+        return self.delete_elements(net, element_type, element_indexes,variant, project_id)
+
 
 if __name__ == '__main__':
     self = PandaHub()

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -1154,7 +1154,7 @@ class PandaHub:
             The created element (element_data with added _id field)
         """
         return self.create_elements(net, element_type, [{"index": element_index, **element_data}],
-                                    project_id, variant, **kwargs)[0]
+                                    project_id=project_id, variant=variant, **kwargs)[0]
 
     def create_elements(self, net: Union[int, str], element_type: str, elements_data: list[dict],
                         project_id: str = None, variant: int = None, **kwargs) -> list[dict]:

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -1056,13 +1056,55 @@ class PandaHub:
                 db[collection].update_one({"_id": document["_id"]},
                                           {"$set": {"object._object": obj}})
 
-    def create_element_in_db(self, net: Union[int, str], element_type: str, element_index: int, data: dict,
-                             variant=None, project_id=None):
-        return self.create_elements_in_db(net, element_type, [{"index": element_index, **data}],
+    def create_element(self, net: Union[int, str], element_type: str, element_index: int, element_data: dict,
+                       variant=None, project_id=None) -> dict:
+        """
+        Creates an element in the database.
+
+        Parameters
+        ----------
+        net: str or int
+            Network to add elements to, either as name or numeric id
+        element_type: str
+            Name of the element type (e.g. bus, line)
+        element_index: int
+            Index of the element to add
+        element_data: dict
+            Field-value dict to create element from
+        project_id: str or None
+            ObjectId (as str) of the project in which the network is stored. Defaults to current active project if None
+        variant: int or None
+            Variant index if elements should be created in a variant
+        Returns
+        -------
+        dict
+            The created element (element_data with added _id field)
+        """
+        return self.create_elements_in_db(net, element_type, [{"index": element_index, **element_data}],
                                           project_id, variant)[0]
 
-    def create_elements_in_db(self, net: Union[int, str], element_type: str, elements_data: list[dict],
-                              project_id: str = None, variant: int = None):
+    def create_elements(self, net: Union[int, str], element_type: str, elements_data: list[dict],
+                              project_id: str = None, variant: int = None) -> list[dict]:
+        """
+        Creates multiple elements of the same type in the database.
+
+        Parameters
+        ----------
+        net: str or int
+            Network to add elements to, either a name or numeric id
+        element_type: str
+            Name of the element type (e.g. bus, line)
+        elements_data: list of dict
+            Field-value dicts to create elements from - must include a valid "index" field!
+        project_id: str or None
+            ObjectId (as str) of the project in which the network is stored. Defaults to current active project if None
+        variant: int or None
+            Variant index if elements should be created in a variant
+        Returns
+        -------
+        list
+            A list of the created elements (elements_data with added _id fields)
+        """
         if project_id:
             self.set_active_project_by_id(project_id)
         self.check_permission("write")
@@ -1971,6 +2013,22 @@ class PandaHub:
         del_res = db[collection_name].delete_many(match_filter)
         return del_res
 
+    #### for
+
+    def create_element_in_db(self, net: Union[int, str], element_type: str, element_index: int, data: dict,
+                             variant=None, project_id=None):
+        warnings.warn(
+            "ph.create_element_in_db was renamed - use ph.create_element instead"
+        )
+        return self.create_element(net, element_type, element_index, data, variant, project_id)
+
+
+    def create_elements_in_db(self, net: Union[int, str], element_type: str, elements_data: list[dict],
+                              project_id: str = None, variant: int = None):
+        warnings.warn(
+            "ph.create_elements_in_db was renamed - use ph.create_elements instead"
+        )
+        return self.create_elements(net, element_type, elements_data, project_id, variant)
 
 if __name__ == '__main__':
     self = PandaHub()

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -954,11 +954,6 @@ class PandaHub:
         db[collection].delete_many({"_id": {"$in": delete_ids}})
         return deletion_targets
 
-    def delete_multiple_elements(self, net, elements: dict[str, Union[list[int], int]], variant=None, project_id=None):
-        deleted = {}
-        for element_type, element_indexes in elements.items():
-            deleted[element_type] = self.delete_net_elements(net, element_type, element_indexes, variant, project_id)
-        return deleted
 
     def set_net_value_in_db(self, net, element, element_index,
                             parameter, value, variant=None, project_id=None):

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -916,12 +916,13 @@ class PandaHub:
     def delete_net_element(self, net, element, element_index, variant=None, project_id=None):
         return self.delete_net_elements(net, element, [element_index], variant, project_id)[0]
 
-    def delete_net_elements(self, net: Union[int, str], element: str, element_indexes: Union[list[int], int],
+    def delete_net_elements(self, net: Union[int, str], element: str, element_indexes: list[int],
                             variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None) -> list[
         dict]:
 
-        if isinstance(element_indexes, int):
-            element_indexes = [element_indexes]
+        if not isinstance(element_indexes, list):
+            raise TypeError("Parameter element_indexes must be a list of ints!")
+
         if variant is not None:
             variant = int(variant)
         if project_id:

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -6,7 +6,7 @@ import logging
 import traceback
 import warnings
 from inspect import signature, _empty
-from typing import Optional, Union
+from typing import Optional, Union, Any
 
 import numpy as np
 import pandas as pd
@@ -937,8 +937,8 @@ class PandaHub:
         return self.delete_elements(net, element_type, [element_index], variant, project_id)[0]
 
     def delete_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
-                            variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None) -> list[
-        dict]:
+                        variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None) -> list[
+        dict[str, Any]]:
         """
         Delete multiple elements of the same type from the database.
 
@@ -1123,7 +1123,7 @@ class PandaHub:
                                           project_id, variant)[0]
 
     def create_elements(self, net: Union[int, str], element_type: str, elements_data: list[dict],
-                              project_id: str = None, variant: int = None) -> list[dict]:
+                              project_id: str = None, variant: int = None) -> list[dict[str, Any]]:
         """
         Creates multiple elements of the same type in the database.
 
@@ -2052,35 +2052,22 @@ class PandaHub:
         del_res = db[collection_name].delete_many(match_filter)
         return del_res
 
-    #### for
+    #### deprecated functions
 
     def create_element_in_db(self, net: Union[int, str], element_type: str, element_index: int, data: dict,
                              variant=None, project_id=None):
-        warnings.warn(
-            "ph.create_element_in_db was renamed - use ph.create_element instead"
-        )
+        warnings.warn("ph.create_element_in_db was renamed - use ph.create_element instead")
         return self.create_element(net, element_type, element_index, data, variant, project_id)
 
 
     def create_elements_in_db(self, net: Union[int, str], element_type: str, elements_data: list[dict],
                               project_id: str = None, variant: int = None):
-        warnings.warn(
-            "ph.create_elements_in_db was renamed - use ph.create_elements instead"
-        )
+        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead")
         return self.create_elements(net, element_type, elements_data, project_id, variant)
 
     def delete_net_element(self, net, element_type, element_index, variant=None, project_id=None):
-        warnings.warn(
-            "ph.delete_net_element was renamed - use ph.delete_element instead"
-        )
+        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead")
         return self.delete_element(net, element_type, element_index, variant, project_id)
-
-    def delete_net_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
-                            variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None):
-        warnings.warn(
-            "ph.delete_net_elementS was renamed - use ph.delete_elementS instead"
-        )
-        return self.delete_elements(net, element_type, element_indexes,variant, project_id)
 
 
 if __name__ == '__main__':

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -967,7 +967,12 @@ class PandaHub:
             The deleted element as dict with all fields
         """
         return self.delete_elements(
-            net, element_type, [element_index], variant, project_id, **kwargs
+            net=net,
+            element_type=element_type,
+            element_indexes=[element_index],
+            variant=variant,
+            project_id=project_id,
+            **kwargs,
         )[0]
 
     def delete_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
@@ -1153,11 +1158,17 @@ class PandaHub:
         dict
             The created element (element_data with added _id field)
         """
-        return self.create_elements(net, element_type, [{"index": element_index, **element_data}],
-                                    project_id=project_id, variant=variant, **kwargs)[0]
+        return self.create_elements(
+            net=net,
+            element_type=element_type,
+            elements_data=[{"index": element_index, **element_data}],
+            variant=variant,
+            project_id=project_id,
+            **kwargs,
+        )[0]
 
     def create_elements(self, net: Union[int, str], element_type: str, elements_data: list[dict],
-                        project_id: str = None, variant: int = None, **kwargs) -> list[dict]:
+                        variant: int = None, project_id: str = None, **kwargs) -> list[dict]:
         """
         Creates multiple elements of the same type in the database.
 
@@ -2086,20 +2097,41 @@ class PandaHub:
 
     #### deprecated functions
 
-    def create_element_in_db(self, net: Union[int, str], element_type: str, element_index: int, data: dict,
+    def create_element_in_db(self, net: Union[int, str], element: str, element_index: int, data: dict,
                              variant=None, project_id=None):
-        warnings.warn("ph.create_element_in_db was renamed - use ph.create_element instead")
-        return self.create_element(net, element_type, element_index, data, variant, project_id)
+        warnings.warn("ph.create_element_in_db was renamed - use ph.create_element instead!")
+        return self.create_element(
+            net=net,
+            element_type=element,
+            element_index=element_index,
+            element_data=data,
+            variant=variant,
+            project_id=project_id,
+        )
 
 
     def create_elements_in_db(self, net: Union[int, str], element_type: str, elements_data: list[dict],
                               project_id: str = None, variant: int = None):
-        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead")
-        return self.create_elements(net, element_type, elements_data, project_id, variant)
+        warnings.warn("ph.create_elements_in_db was renamed - use ph.create_elements instead! "
+                      "Watch out for changed order of project_id and variant args")
+        return self.create_elements(
+            net=net,
+            element_type=element_type,
+            elements_data=elements_data,
+            variant=variant,
+            project_id=project_id,
+        )
 
-    def delete_net_element(self, net, element_type, element_index, variant=None, project_id=None):
-        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead")
-        return self.delete_element(net, element_type, element_index, variant, project_id)
+
+    def delete_net_element(self, net, element, element_index, variant=None, project_id=None):
+        warnings.warn("ph.delete_net_element was renamed - use ph.delete_element instead!")
+        return self.delete_element(
+            net=net,
+            element_type=element,
+            element_index=element_index,
+            variant=variant,
+            project_id=project_id,
+        )
 
 
 if __name__ == '__main__':

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -914,10 +914,19 @@ class PandaHub:
             return document[parameter]
 
     def delete_net_element(self, net, element, element_index, variant=None, project_id=None):
+        return self.delete_net_elements(net, element, [element_index], variant, project_id)[0]
+
+    def delete_net_elements(self, net: Union[int, str], element: str, element_indexes: Union[list[int], int],
+                            variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None) -> list[
+        dict]:
+
+        if isinstance(element_indexes, int):
+            element_indexes = [element_indexes]
         if variant is not None:
             variant = int(variant)
         if project_id:
             self.set_active_project_by_id(project_id)
+
         self.check_permission("write")
         db = self._get_project_database()
         collection = self._collection_name_of_element(element)
@@ -927,18 +936,29 @@ class PandaHub:
         else:
             net_id = net
 
-        element_filter = {"index": element_index, "net_id": int(net_id), **self.get_variant_filter(variant)}
+        element_filter = {"index": {"$in": element_indexes}, "net_id": int(net_id), **self.get_variant_filter(variant)}
 
-        target = db[collection].find_one(element_filter)
-        if target is None:
-            # element does not exist in net
-            return
-        if variant and target["var_type"] == "base":
-            db[collection].update_one({"_id": target["_id"]},
-                                      {"$addToSet": {"not_in_var": variant}})
+        deletion_targets = list(db[collection].find(element_filter))
+        if not deletion_targets:
+            return []
+
+        if variant:
+            delete_ids_variant, delete_ids = [], []
+            for target in deletion_targets:
+                delete_ids_variant.append(target["_id"]) if target["var_type"] == "base" else delete_ids.append(
+                    target["_id"])
+            db[collection].update_many({"_id": {"$in": delete_ids_variant}},
+                                       {"$addToSet": {"not_in_var": variant}})
         else:
-            db[collection].delete_one({"_id": target["_id"]})
-        return target
+            delete_ids = [target["_id"] for target in deletion_targets]
+        db[collection].delete_many({"_id": {"$in": delete_ids}})
+        return deletion_targets
+
+    def delete_multiple_elements(self, net, elements: dict[str, Union[list[int], int]], variant=None, project_id=None):
+        deleted = {}
+        for element_type, element_indexes in elements.items():
+            deleted[element_type] = self.delete_net_elements(net, element_type, element_indexes, variant, project_id)
+        return deleted
 
     def set_net_value_in_db(self, net, element, element_index,
                             parameter, value, variant=None, project_id=None):

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -6,7 +6,8 @@ import logging
 import traceback
 import warnings
 from inspect import signature, _empty
-from typing import Optional, Union, Any
+from pymongo.errors import ServerSelectionTimeoutError
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -913,7 +914,7 @@ class PandaHub:
         else:
             return document[parameter]
 
-    def delete_element(self, net, element_type, element_index, variant=None, project_id=None):
+    def delete_element(self, net, element_type, element_index, variant=None, project_id=None, **kwargs) -> dict:
         """
         Delete an element from the database.
 
@@ -934,11 +935,13 @@ class PandaHub:
         dict
             The deleted element as dict with all fields
         """
-        return self.delete_elements(net, element_type, [element_index], variant, project_id)[0]
+        return self.delete_elements(
+            net, element_type, [element_index], variant, project_id, **kwargs
+        )[0]
 
     def delete_elements(self, net: Union[int, str], element_type: str, element_indexes: list[int],
-                        variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None) -> list[
-        dict[str, Any]]:
+                        variant: Union[int, list[int], None] = None, project_id: Union[str, None] = None, **kwargs) -> \
+        list[dict]:
         """
         Delete multiple elements of the same type from the database.
 
@@ -996,7 +999,7 @@ class PandaHub:
 
 
     def set_net_value_in_db(self, net, element_type, element_index,
-                            parameter, value, variant=None, project_id=None):
+                            parameter, value, variant=None, project_id=None, **kwargs):
         logger.info(f"Setting  {parameter} = {value} in {element_type} with index {element_index} and variant {variant}")
         if variant is not None:
             variant = int(variant)
@@ -1096,7 +1099,7 @@ class PandaHub:
                                           {"$set": {"object._object": obj}})
 
     def create_element(self, net: Union[int, str], element_type: str, element_index: int, element_data: dict,
-                       variant=None, project_id=None) -> dict:
+                       variant=None, project_id=None, **kwargs) -> dict:
         """
         Creates an element in the database.
 
@@ -1120,10 +1123,10 @@ class PandaHub:
             The created element (element_data with added _id field)
         """
         return self.create_elements(net, element_type, [{"index": element_index, **element_data}],
-                                          project_id, variant)[0]
+                                    project_id, variant, **kwargs)[0]
 
     def create_elements(self, net: Union[int, str], element_type: str, elements_data: list[dict],
-                              project_id: str = None, variant: int = None) -> list[dict[str, Any]]:
+                        project_id: str = None, variant: int = None, **kwargs) -> list[dict]:
         """
         Creates multiple elements of the same type in the database.
 
@@ -1163,8 +1166,8 @@ class PandaHub:
             self._ensure_dtypes(element_type, elm_data)
             data.append({**elm_data, **var_data, "net_id": net_id})
         collection = self._collection_name_of_element(element_type)
-        insert_result = db[collection].insert_many(data)
-        return [z[0] | {"_id": z[1]} for z in zip(data, insert_result.inserted_ids)]
+        db[collection].insert_many(data, ordered=False)
+        return data
 
     def _add_missing_defaults(self, db, net_id, element_type, element_data):
         func_str = f"create_{element_type}"

--- a/pandahub/test/test_networks.py
+++ b/pandahub/test/test_networks.py
@@ -131,7 +131,7 @@ def test_access_and_set_single_values(ph):
     value = ph.get_net_value_from_db(name, element, index, parameter)
     assert value == p_mw_new
 
-    ph.delete_net_element(name, element, index)
+    ph.delete_element(name, element, index)
     with pytest.raises(PandaHubError):
         ph.get_net_value_from_db(name, element, index, parameter)
     net = ph.get_net_from_db(name)


### PR DESCRIPTION
Make naming and signatures for create and delete functions in lib.PandaHub consistent, add docstrings and deprecate old functions. 

**Deprecated functions**
create_element_in_db --> create_element
create_elements_in_db --> create_elements
delete_net_element --> delete_element

**New functions**
delete_elements (vectorized version of delete_element)
get_project_setting_value (Retrieve the value of a setting)