### PR TITLE
Custom element filters for get_subnet

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -7,7 +7,7 @@ import traceback
 import warnings
 from inspect import signature, _empty
 from pymongo.errors import ServerSelectionTimeoutError
-from typing import Optional, Union
+from typing import Optional, Union, Callable
 
 import numpy as np
 import pandas as pd
@@ -619,9 +619,17 @@ class PandaHub:
         return self.get_subnet_from_db_by_id(_id, bus_filter=bus_filter, include_results=include_results,
                                              add_edge_branches=add_edge_branches, geo_mode=geo_mode, variants=variants)
 
-    def get_subnet_from_db_by_id(self, net_id, bus_filter=None, include_results=True,
-                           add_edge_branches=True, geo_mode="string", variants=[],
-                           ignore_elements=[]):
+    def get_subnet_from_db_by_id(
+        self,
+        net_id,
+        bus_filter=None,
+        include_results=True,
+        add_edge_branches=True,
+        geo_mode="string",
+        variants=[],
+        ignore_elements=[],
+        additional_filters: dict[str, Callable[[list[int]], dict]] = {}
+    ) -> pp.pandapowerNet:
         db = self._get_project_database()
         meta = self._get_network_metadata(db, net_id)
         dtypes = db["_networks"].find_one({"_id": net_id}, projection={"dtypes"})
@@ -673,7 +681,7 @@ class PandaHub:
                             set(net.trafo3w.lv_bus.values) | set(net.switch.bus) | set(net.switch.element)
             branch_buses_outside = [int(b) for b in branch_buses - set(buses)]
             self._add_element_from_collection(net, db, "bus", net_id, geo_mode=geo_mode, variants=variants,
-                                              filter={"index": {"$in": branch_buses_outside}},
+                                              element_filter={"index": {"$in": branch_buses_outside}},
                                               dtypes=dtypes)
             buses = net.bus.index.tolist()
 
@@ -701,14 +709,22 @@ class PandaHub:
         # add node elements
         node_elements = ["load", "sgen", "gen", "ext_grid", "shunt", "xward", "ward", "motor", "storage"]
         branch_elements = ["trafo", "line", "trafo3w", "switch", "impedance"]
-        all_elements = node_elements + branch_elements + ["bus"]
+        all_elements = node_elements + branch_elements + ["bus"] + list(additional_filters.keys())
         all_elements = list(set(all_elements) - set(ignore_elements))
+
+        # Add elements for which the user has provided a filter function
+        for element, filter_func in additional_filters.items():
+            element_filter = filter_func(buses)
+            self._add_element_from_collection(net, db, element, net_id,
+                                              element_filter=element_filter, geo_mode=geo_mode,
+                                              include_results=include_results,
+                                              variants=variants, dtypes=dtypes)
 
         # add all node elements that are connected to buses within the network
         for element in node_elements:
-            filter = {"bus": {"$in": buses}}
+            element_filter = {"bus": {"$in": buses}}
             self._add_element_from_collection(net, db, element, net_id,
-                                              filter=filter, geo_mode=geo_mode,
+                                              element_filter=element_filter, geo_mode=geo_mode,
                                               include_results=include_results,
                                               variants=variants, dtypes=dtypes)
 
@@ -722,13 +738,13 @@ class PandaHub:
             # for tables that share an index with an element (e.g. load->res_load) load only relevant entries
             for element in all_elements:
                 if table_name.startswith(element + "_") or table_name.startswith("net_res_" + element):
-                    filter = {"index": {"$in": net[element].index.tolist()}}
+                    element_filter = {"index": {"$in": net[element].index.tolist()}}
                     break
             else:
                 # all other tables (e.g. std_types) are loaded without filter
-                filter = None
+                element_filter = None
             self._add_element_from_collection(net, db, table_name, net_id,
-                                              filter=filter, geo_mode=geo_mode,
+                                              element_filter=element_filter, geo_mode=geo_mode,
                                               include_results=include_results,
                                               variants=variants, dtypes=dtypes)
         self.deserialize_and_update_data(net, meta)
@@ -872,7 +888,7 @@ class PandaHub:
         return db["_networks"].find_one({"_id": net_id})
 
     def _add_element_from_collection(self, net, db, element_type, net_id,
-                                     filter=None, include_results=True,
+                                     element_filter=None, include_results=True,
                                      only_tables=None, geo_mode="string", variants=[], dtypes=None):
         if only_tables is not None and not element_type in only_tables:
             return
@@ -880,14 +896,15 @@ class PandaHub:
             return
         variants_filter = self.get_variant_filter(variants)
         filter_dict = {"net_id": net_id, **variants_filter}
-        if filter is not None:
-            if "$or" in filter_dict.keys() and "$or" in filter.keys():
+        if element_filter is not None:
+            if "$or" in filter_dict.keys() and "$or" in element_filter.keys():
                 # if 'or' is in both filters create 'and' with
                 # both to avoid override during filter merge
-                filter_and = {"$and": [{"$or": filter_dict.pop("$or")}, {"$or": filter.pop("$or")}]}
-                filter_dict = {**filter_dict, **filter, **filter_and}
+                filter_and = {"$and": [{"$or": filter_dict.pop("$or")}, {"$or": element_filter.pop("$or")}]}
+                filter_dict = {**filter_dict, **element_filter, **filter_and}
             else:
-                filter_dict = {**filter_dict, **filter}
+                filter_dict = {**filter_dict, **element_filter}
+
         data = list(db[self._collection_name_of_element(element_type)].find(filter_dict))
         if len(data) == 0:
             return

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -714,6 +714,8 @@ class PandaHub:
 
         # Add elements for which the user has provided a filter function
         for element, filter_func in additional_filters.items():
+            if element in ignore_elements:
+                continue
             element_filter = filter_func(buses)
             self._add_element_from_collection(net, db, element, net_id,
                                               element_filter=element_filter, geo_mode=geo_mode,


### PR DESCRIPTION
Introduce "additional_filters" argument to get_subnet functions which allows to filter on element tables not defined in pandahub, based on the net returned from the default elements. The argument is a dict of element table names with functions which recieve the pandapower net and return a mongodb query filter.

WIP - signature and implementation may change