### PR TITLE
added option to optionally localize retreived timeseries to UTC

### DIFF
--- a/pandahub/api/routers/timeseries.py
+++ b/pandahub/api/routers/timeseries.py
@@ -22,6 +22,7 @@ class GetTimeSeriesModel(BaseModel):
     timestamp_range: Optional[tuple] = None
     exclude_timestamp_range: Optional[tuple] = None
     collection_name: Optional[str] = "timeseries"
+    as_utc: Optional[bool] = False
 
 
 @router.post("/get_timeseries_from_db")
@@ -39,6 +40,7 @@ class MultiGetTimeSeriesModel(BaseModel):
     timestamp_range: Optional[tuple] = None
     exclude_timestamp_range: Optional[tuple] = None
     collection_name: Optional[str] = "timeseries"
+    as_utc: Optional[bool] = False
 
 
 @router.post("/multi_get_timeseries_from_db")


### PR DESCRIPTION
Timestamps are stored in UTC format in MongoDB. Before this PR timeseries timestamps retreived from the database had no localisation which resulted in shifted timestamps in applications because they had no information about the timezone.
This PR adds an option to localize timestamps as UTC to address this issue.