### PR TITLE
Fix: pyproject requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors=[
 description = "Data hub for pandapower and pandapipes networks based on MongoDB"
 readme = "README.md"
 license = { file = "LICENSE" }
+dynamic = ["dependencies"]
 requires-python = ">=3.8"
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
#51 moved requirements out of pyproject.toml but missed a line to properly parse the requirements.txt