### PR TITLE
enforce specifying variant argument as int instead of list

### DIFF
--- a/VARIANTS.md
+++ b/VARIANTS.md
@@ -14,7 +14,7 @@ variants in which the element has been removed or changed.
 
 Elements with var_types "change" and "addition" have an additional field "variant" referencing the variant index for the change/addition.
 
-`PandaHub.get_variant_filter(variants)` can be used to generate a mongodb query filter mixin which restricts query results to a given variant or variants.
+`PandaHub.get_variant_filter(variant)` can be used to generate a mongodb query filter mixin which restricts query results to a given variant or variants.
 
 Example variant filter for single variant with index 1:
 

--- a/pandahub/api/routers/variants.py
+++ b/pandahub/api/routers/variants.py
@@ -25,7 +25,7 @@ def get_variants(data: GetVariantsModel, ph=Depends(pandahub)):
     variants_collection = ph.get_project_database("variant")
 
     variants = variants_collection.find({"net_id": data.net_id}, projection={"_id": 0})
-    return [variant.pop("index") for variant in variants]
+    return {variant.pop("index"): variant for variant in variants}
 
 
 class CreateVariantModel(BaseModel):

--- a/pandahub/api/routers/variants.py
+++ b/pandahub/api/routers/variants.py
@@ -25,10 +25,7 @@ def get_variants(data: GetVariantsModel, ph=Depends(pandahub)):
     variants_collection = ph.get_project_database("variant")
 
     variants = variants_collection.find({"net_id": data.net_id}, projection={"_id": 0})
-    response = {}
-    for var in variants:
-        response[var.pop("index")] = var
-    return response
+    return [variant.pop("index") for variant in variants]
 
 
 class CreateVariantModel(BaseModel):


### PR DESCRIPTION
Many generic functions working on a network took a "variants" argument which could be list[int] or None, with empty list or None specifying the base variant. However, activating multiple variants on the same net was never properly supported.

This PR concludes the deprecation of activating multiple variants at once:
* rename remaining instances of function argument "variants" to "variant"
* get_variant_filter takes an variant:int argument and raise a ValueError if the type does not match