### PR TITLE
[Fix] more robust variant creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.3.9]
+
+    -  BREAKING: changed signatures of create_variant function and route
+
 ## [0.3.8]
 
     -  BREAKING: specifying variant as list will raise an error instead of a deprecation warning

--- a/pandahub/api/routers/variants.py
+++ b/pandahub/api/routers/variants.py
@@ -30,13 +30,23 @@ def get_variants(data: GetVariantsModel, ph=Depends(pandahub)):
 
 class CreateVariantModel(BaseModel):
     project_id: str
-    variant_data: dict
+    net_id: int
+    name: str | None = None
+    default_name: str | None = None
+
+
+class CreateVariantResponseModel(BaseModel):
+    net_id: int
+    index: int
+    name: str | None = None
+    date_created: int
+    date_changed: int
+
 
 @router.post("/create_variant")
-def create_variant(data: CreateVariantModel, ph=Depends(pandahub)):
-    project_id = data.project_id
-    ph.set_active_project_by_id(project_id)
-    return ph.create_variant(data.variant_data)
+def create_variant(data: CreateVariantModel, ph=Depends(pandahub)) -> CreateVariantResponseModel:
+    ph.set_active_project_by_id(data.project_id)
+    return ph.create_variant(net_id=data.net_id, name=data.name, default_name=data.default_name)
 
 class DeleteVariantModel(BaseModel):
     project_id: str

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -1122,7 +1122,7 @@ class PandaHub:
                         element_data["var_type"] = element_data["var_type"].fillna("base")
                     else:
                         element_data["var_type"] = "base"
-                        # element_data["not_in_var"] = []
+                        element_data["not_in_var"] = np.empty((len(element_data.index), 0)).tolist()
                         element_data["variant"] = None
                 element_data = convert_element_to_dict(element_data, net_id, self._datatypes.get(element))
                 self._write_element_to_db(db, element, element_data)

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -92,6 +92,7 @@ class PandaHub:
         user_id=None,
         datatypes=DATATYPES,
         mongodb_indexes=MONGODB_INDEXES,
+        elements_without_vars = None,
     ):
         mongo_client_args = {
             "host": connection_url,
@@ -116,6 +117,7 @@ class PandaHub:
                 {"var_type": np.nan},
             ]
         }
+        self._elements_without_vars = ["variant"] if elements_without_vars is None else elements_without_vars
         if check_server_available:
             self.server_is_available()
 
@@ -1115,10 +1117,13 @@ class PandaHub:
                 if element_data.empty:
                     continue
                 element_data = element_data.copy(deep=True)
-                if "var_type" in element_data:
-                    element_data["var_type"] = element_data["var_type"].fillna("base")
-                else:
-                    element_data["var_type"] = "base"
+                if element not in self._elements_without_vars:
+                    if "var_type" in element_data:
+                        element_data["var_type"] = element_data["var_type"].fillna("base")
+                    else:
+                        element_data["var_type"] = "base"
+                        # element_data["not_in_var"] = []
+                        element_data["variant"] = None
                 element_data = convert_element_to_dict(element_data, net_id, self._datatypes.get(element))
                 self._write_element_to_db(db, element, element_data)
 
@@ -1191,6 +1196,11 @@ class PandaHub:
         return self._get_id_from_name(name, db) is not None
 
     def _get_net_collections(self, db, with_areas=True):
+        return self.get_net_collections(db, with_areas)
+
+    def get_net_collections(self, db=None, with_areas=True):
+        if db is None:
+            db = self.get_project_database()
         if with_areas:
             collection_filter = {"name": {"$regex": "^net_"}}
         else:
@@ -1366,7 +1376,7 @@ class PandaHub:
         """
         if not isinstance(element_indexes, list):
             raise TypeError("Parameter element_indexes must be a list of ints!")
-        validate_variant_type(variant)
+        self.validate_variant(variant, element_type)
         if project_id:
             self.set_active_project_by_id(project_id)
 
@@ -1415,7 +1425,7 @@ class PandaHub:
         project_id=None,
         **kwargs,
     ):
-        validate_variant_type(variant)
+        self.validate_variant(variant, element_type)
         if project_id:
             self.set_active_project_by_id(project_id)
         self.check_permission("write")
@@ -1487,7 +1497,7 @@ class PandaHub:
         variant=None,
         project_id=None,
     ):
-        validate_variant_type(variant)
+        self.validate_variant(variant, element_type)
         if project_id:
             self.set_active_project_by_id(project_id)
         self.check_permission("write")
@@ -1613,15 +1623,19 @@ class PandaHub:
         list
             A list of the created elements (elements_data with added _id fields)
         """
-        validate_variant_type(variant)
+        self.validate_variant(variant, element_type)
         if project_id:
             self.set_active_project_by_id(project_id)
         self.check_permission("write")
         db = self._get_project_database()
-        if variant is None:
-            var_data = {"var_type": "base", "not_in_var": [], "variant": None}
+        if element_type in self._elements_without_vars:
+            var_data = {}
         else:
-            var_data = {"var_type": "addition", "not_in_var": [], "variant": variant}
+            if variant is None:
+                var_data = {"var_type": "base", "not_in_var": [], "variant": None}
+            else:
+                var_data = {"var_type": "addition", "not_in_var": [], "variant": variant}
+
         if isinstance(net, str):
             net_id = self._get_id_from_name(net, db)
         else:
@@ -1781,12 +1795,17 @@ class PandaHub:
         dict
             mongodb query filter for the given variant
         """
-        validate_variant_type(variant)
+        self.validate_variant(variant)
         if variant is None:
             return self.base_variant_filter
         return {"$or": [{"var_type": "base", "not_in_var": {"$ne": variant}},
                         {"var_type": {"$in": ["change", "addition"]}, "variant": variant}, ]}
 
+    def validate_variant(self, variant: int | None, element_type: str | None = None):
+        """Raise a ValueError if variant is not int | None or element_type does not support variants."""
+        validate_variant_type(variant)
+        if element_type is not None and variant is not None and element_type in self._elements_without_vars:
+            raise ValueError(f"{element_type} does not support variants")
 
     # -------------------------
     # Bulk operations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pandahub"
-version = "0.3.8"  # File format version '__format_version__' is tracked in __init__.py
+version = "0.3.9"  # File format version '__format_version__' is tracked in __init__.py
 authors=[
     { name = "Jan Ulffers", email = "jan.ulffers@iee.fraunhofer.de" },
     { name = "Leon Thurner", email = "leon.thurner@retoflow.de" },


### PR DESCRIPTION
Variants require certain fields on elements which use them. This PR tries to ensure those are always set when nets are imported or elements created, instead of adding them only when the first variant in a project is created.

The variant creation function (and API endpoint) now take named arguments instead of a generic dict, and add created/changed timestamps. 

Variants are indexed from 0 (previously the first index was 1).

Add more validation for the active variant (type checking + element type has support for variants).