### PR TITLE
 [Fix] network id handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.3.9]
+
+    -  BREAKING: inserting multiple networks with the same name does not represent an error anymore, networks are only unique by their net_id (_id field of the collection)
+    -  BREAKING: passing net_id as str will not remap to the project name internally but look up on the _id field
+    -  IMPROVED: fix race condition when calling write_network_to_db without net_id
+
 ## [0.3.8]
 
     -  BREAKING: specifying variant as list will raise an error instead of a deprecation warning

--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -32,7 +32,7 @@ def get_net_from_db(data: GetNetFromDB, ph=Depends(pandahub)):
 
 class WriteNetwork(BaseModel):
     project_id: str
-    net: pp.pandapowerNet | pps.pandapipesNet
+    net: str
     name: str
     overwrite: Optional[bool] = True
 

--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -25,7 +25,7 @@ class GetNetFromDB(BaseModel):
 
 @router.post("/get_net_from_db")
 def get_net_from_db(data: GetNetFromDB, ph=Depends(pandahub)):
-    net = ph.get_net_from_db(**data.model_dump())
+    net = ph.get_network_by_name(**data.model_dump())
     return pp.to_json(net)
 
 

--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -49,7 +49,7 @@ def write_network_to_db(data: WriteNetwork, ph=Depends(pandahub)):
 
 class BaseCRUDModel(BaseModel):
     project_id: str
-    net: str
+    net_id: int | str
     element_type: str
 
 class GetNetValueModel(BaseCRUDModel):

--- a/pandahub/api/routers/net.py
+++ b/pandahub/api/routers/net.py
@@ -1,6 +1,7 @@
 from typing import Optional, Any
 
 import pandapower as pp
+import pandapipes as pps
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
@@ -31,7 +32,7 @@ def get_net_from_db(data: GetNetFromDB, ph=Depends(pandahub)):
 
 class WriteNetwork(BaseModel):
     project_id: str
-    net: str
+    net: pp.pandapowerNet | pps.pandapipesNet
     name: str
     overwrite: Optional[bool] = True
 

--- a/pandahub/api/routers/variants.py
+++ b/pandahub/api/routers/variants.py
@@ -17,7 +17,7 @@ router = APIRouter(
 
 class GetVariantsModel(BaseModel):
     project_id: str
-    net_id: int
+    net_id: int | str
 
 @router.post("/get_variants")
 def get_variants(data: GetVariantsModel, ph=Depends(pandahub)):
@@ -40,7 +40,7 @@ def create_variant(data: CreateVariantModel, ph=Depends(pandahub)):
 
 class DeleteVariantModel(BaseModel):
     project_id: str
-    net_id: int
+    net_id: int | str
     index: int
 
 @router.post("/delete_variant")
@@ -51,7 +51,7 @@ def delete_variant(data: DeleteVariantModel, ph=Depends(pandahub)):
 
 class UpdateVariantModel(BaseModel):
     project_id: str
-    net_id: int
+    net_id: int | str
     index: int
     data: dict
 

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -1134,7 +1134,7 @@ class PandaHub:
                     msg = f"Network with net_id {net_id} already exists"
                     raise PandaHubError(msg)
 
-        networks_coll.update_one({"_id": net_id}, {"name": name, "sector": sector})
+        networks_coll.update_one({"_id": net_id}, {"$set": {"name": name, "sector": sector}})
 
         data = {}
         dtypes = {}
@@ -3084,7 +3084,7 @@ class PandaHub:
         warnings.warn(msg, DeprecationWarning)
         self.get_network(*args, **kwargs)
 
-    def get_subnet_from_db(*args, **kwargs):
+    def get_subnet_from_db(self, *args, **kwargs):
         msg = ("Getting a network by name can be ambiguous and will throw an error if more than one Network with the "
                "given name exists. Preferably, switch to get_subnet() and pass the network id. "
                "If you want to continue to retrieve a subnet by its name, switch to get_subnet_by_name(). "
@@ -3092,7 +3092,7 @@ class PandaHub:
         warnings.warn(msg, DeprecationWarning)
         return self.get_subnet_by_name(*args, **kwargs)
 
-    def get_subnet_from_db_by_id(*args, **kwargs):
+    def get_subnet_from_db_by_id(self,*args, **kwargs):
         msg = "Renamed - use get_subnet() as drop-in replacement. This function will be removed in future versions."
         warnings.warn(msg, DeprecationWarning)
         return self.get_subnet(*args, **kwargs)

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -764,7 +764,7 @@ class PandaHub:
         net = package.create_empty_network()
 
         # add all elements that are stored as dataframes
-        collection_names = self._get_net_collections(db)
+        collection_names = self.get_net_collections(db)
         for collection_name in collection_names:
             el = self._element_name_of_collection(collection_name)
             self._add_element_from_collection(
@@ -1036,7 +1036,7 @@ class PandaHub:
             )
 
         # add all other collections
-        collection_names = self._get_net_collections(db)
+        collection_names = self.get_net_collections(db)
         for collection in collection_names:
             table_name = self._element_name_of_collection(collection)
             # skip all element tables that we have already added
@@ -1783,7 +1783,7 @@ class PandaHub:
         del data["_id"]
 
         if index == 1:
-            for coll in self._get_net_collections(db):
+            for coll in self.get_net_collections(db):
                 db[coll].update_many(
                     {"$or": [{"var_type": None}, {"var_type": np.nan}]},
                     {"$set": {"var_type": "base", "not_in_var": [], "variant": None}},
@@ -1792,7 +1792,7 @@ class PandaHub:
 
     def delete_variant(self, net_id, index):
         db = self._get_project_database()
-        collection_names = self._get_net_collections(db)
+        collection_names = self.get_net_collections(db)
         for coll in collection_names:
             # remove references to deleted objects
             db[coll].update_many(
@@ -3075,12 +3075,12 @@ class PandaHub:
         msg = ("Getting a network by name can be ambiguous and will throw an error if more than one Network with the "
                "given name exists. Preferably, switch to get_network() and pass the network id. "
                "If you want to continue to retrieve a network by its name, switch to get_network_by_name(). "
-               "This function will be removed in future versions.")
+               "get_net_from_db() will be removed in future versions.")
         warnings.warn(msg, DeprecationWarning)
         return self.get_network_by_name(*args, **kwargs)
 
     def get_net_from_db_by_id(self, *args, **kwargs):
-        msg = "Renamed - use get_network() as drop-in replacement. This function will be removed in future versions."
+        msg = "get_net_from_db_by_id() has been renamed - use get_network() as drop-in replacement. This function will be removed in future versions."
         warnings.warn(msg, DeprecationWarning)
         self.get_network(*args, **kwargs)
 
@@ -3088,12 +3088,12 @@ class PandaHub:
         msg = ("Getting a network by name can be ambiguous and will throw an error if more than one Network with the "
                "given name exists. Preferably, switch to get_subnet() and pass the network id. "
                "If you want to continue to retrieve a subnet by its name, switch to get_subnet_by_name(). "
-               "This function will be removed in future versions.")
+               "get_subnet_from_db() will be removed in future versions.")
         warnings.warn(msg, DeprecationWarning)
         return self.get_subnet_by_name(*args, **kwargs)
 
     def get_subnet_from_db_by_id(self,*args, **kwargs):
-        msg = "Renamed - use get_subnet() as drop-in replacement. This function will be removed in future versions."
+        msg = "get_subnet_from_db_by_id() has been renamed - use get_subnet() as drop-in replacement. This function will be removed in future versions."
         warnings.warn(msg, DeprecationWarning)
         return self.get_subnet(*args, **kwargs)
 
@@ -3101,12 +3101,12 @@ class PandaHub:
         msg = ("Deleting a network by name can be ambiguous and will throw an error if more than one Network with the "
                "given name exists. Preferably, switch to delete_network() and pass the network id. "
                "If you want to continue to delete a net by its name, switch to delete_network_by_name(). "
-               "This function will be removed in future versions.")
+               "delete_net_from_db() will be removed in future versions.")
         warnings.warn(msg, DeprecationWarning)
         return self.delete_network_by_name(name)
 
     def _get_net_collections(self, db, with_areas=True):
-        msg = "Renamed - use get_net_collections() as drop-in replacement. This function will be removed in future versions."
+        msg = "_get_net_collections() has been made public - use get_net_collections() as drop-in replacement. This function will be removed in future versions."
         warnings.warn(msg, DeprecationWarning)
         return self.get_net_collections(db, with_areas)
 

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -722,16 +722,16 @@ class PandaHub:
             self.set_active_project_by_id(project_id)
         self.check_permission("read")
         db = self._get_project_database()
-        _id = self._get_net_id_from_name(name, db)
-        if _id is None:
+        net_id = self._get_net_id_from_name(name, db)
+        if net_id is None:
             return None
         return self.get_network(
-            _id, include_results, only_tables, geo_mode=geo_mode, variant=variant, convert=convert
+            net_id, include_results, only_tables, geo_mode=geo_mode, variant=variant, convert=convert
         )
 
     def get_network(
         self,
-        _id,
+        net_id,
         include_results=True,
         only_tables=None,
         convert=True,
@@ -740,7 +740,7 @@ class PandaHub:
     ):
         self.check_permission("read")
         return self._get_net_from_db_by_id(
-            _id,
+            net_id,
             include_results,
             only_tables,
             convert=convert,
@@ -750,7 +750,7 @@ class PandaHub:
 
     def _get_net_from_db_by_id(
         self,
-        id_,
+        net_id,
         include_results=True,
         only_tables=None,
         convert=True,
@@ -758,7 +758,7 @@ class PandaHub:
         variant=None,
     ):
         db = self._get_project_database()
-        meta = self._get_network_metadata(db, id_)
+        meta = self._get_network_metadata(db, net_id)
 
         package = pp if meta.get("sector", "power") == "power" else pps
         net = package.create_empty_network()
@@ -771,7 +771,7 @@ class PandaHub:
                 net,
                 db,
                 el,
-                id_,
+                net_id,
                 include_results=include_results,
                 only_tables=only_tables,
                 geo_mode=geo_mode,
@@ -813,11 +813,11 @@ class PandaHub:
     ):
         self.check_permission("read")
         db = self._get_project_database()
-        _id = self._get_net_id_from_name(name, db)
-        if _id is None:
+        net_id = self._get_net_id_from_name(name, db)
+        if net_id is None:
             return None
         return self.get_subnet(
-            _id,
+            net_id,
             bus_filter=bus_filter,
             include_results=include_results,
             add_edge_branches=add_edge_branches,

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -707,7 +707,8 @@ class PandaHub:
         db = self._get_project_database()
         return list(db["_networks"].find())
 
-    def get_net_from_db(
+
+    def get_network_by_name(
         self,
         name,
         include_results=True,
@@ -724,13 +725,13 @@ class PandaHub:
         _id = self._get_id_from_name(name, db)
         if _id is None:
             return None
-        return self.get_net_from_db_by_id(
+        return self.get_network(
             _id, include_results, only_tables, geo_mode=geo_mode, variant=variant, convert=convert
         )
 
-    def get_net_from_db_by_id(
+    def get_network(
         self,
-        id,
+        _id,
         include_results=True,
         only_tables=None,
         convert=True,
@@ -739,7 +740,7 @@ class PandaHub:
     ):
         self.check_permission("read")
         return self._get_net_from_db_by_id(
-            id,
+            _id,
             include_results,
             only_tables,
             convert=convert,
@@ -797,7 +798,8 @@ class PandaHub:
                     value = json.loads(value[11:], cls=io_pp.PPJSONDecoder, registry_class=registry)
                 net[key] = value
 
-    def get_subnet_from_db(
+
+    def get_subnet_by_name(
         self,
         name,
         bus_filter=None,
@@ -814,7 +816,7 @@ class PandaHub:
         _id = self._get_id_from_name(name, db)
         if _id is None:
             return None
-        return self.get_subnet_from_db_by_id(
+        return self.get_subnet(
             _id,
             bus_filter=bus_filter,
             include_results=include_results,
@@ -824,7 +826,7 @@ class PandaHub:
             additional_filters=additional_filters,
         )
 
-    def get_subnet_from_db_by_id(
+    def get_subnet(
         self,
         net_id,
         bus_filter=None,
@@ -3017,6 +3019,32 @@ class PandaHub:
             variant=variant,
             project_id=project_id,
         )
+
+    def get_net_from_db(self, *args, **kwargs):
+        msg = ("Getting a network by name can be ambiguous and will throw an error if more than one Network with the "
+               "given name exists. Preferably, switch to get_network() and pass the network id. "
+               "If you want to continue to retrieve a network by its name, switch to get_network_by_name(). "
+               "This function will be removed in future versions.")
+        warnings.warn(msg, DeprecationWarning)
+        return self.get_network_by_name(*args, **kwargs)
+
+    def get_net_from_db_by_id(self, *args, **kwargs):
+        msg = "Renamed - use get_network() as drop-in replacement. This function will be removed in future versions."
+        warnings.warn(msg, DeprecationWarning)
+        self.get_network(*args, **kwargs)
+
+    def get_subnet_from_db(*args, **kwargs):
+        msg = ("Getting a network by name can be ambiguous and will throw an error if more than one Network with the "
+               "given name exists. Preferably, switch to get_subnet() and pass the network id. "
+               "If you want to continue to retrieve a subnet by its name, switch to get_subnet_by_name(). "
+               "This function will be removed in future versions.")
+        warnings.warn(msg, DeprecationWarning)
+        return self.get_subnet_by_name(*args, **kwargs)
+
+    def get_subnet_from_db_by_id(*args, **kwargs):
+        msg = "Renamed - use get_subnet() as drop-in replacement. This function will be removed in future versions."
+        warnings.warn(msg, DeprecationWarning)
+        return self.get_subnet(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pandahub"
-version = "0.3.8"  # File format version '__format_version__' is tracked in __init__.py
+version = "0.3.9"  # File format version '__format_version__' is tracked in __init__.py
 authors=[
     { name = "Jan Ulffers", email = "jan.ulffers@iee.fraunhofer.de" },
     { name = "Leon Thurner", email = "leon.thurner@retoflow.de" },

--- a/test/performance_test.py
+++ b/test/performance_test.py
@@ -17,13 +17,13 @@ def get_test_net(n_buses):
     pp.create_sgens(net, net.bus.index[::50], p_mw=0, q_mvar=0)
     pp.create_gens(net, net.bus.index[::1000], p_mw=0, q_mvar=0)
     pp.create_lines(net, net.bus.index[::2], net.bus.index[1::2], 1.0, "NAYY 4x50 SE")
-    pp.create_transformers_from_parameters(net, net.bus.index[::1000], 
+    pp.create_transformers_from_parameters(net, net.bus.index[::1000],
                                             net.bus.index[1::1000],
                                             vn_hv_kv=20.,
                                             vn_lv_kv=0.4,
                                             sn_mva=0.4,
                                             vkr_percent=5.,
-                                            vk_percent=0.5, 
+                                            vk_percent=0.5,
                                             pfe_kw=0,
                                             i0_percent=0,
                                             )
@@ -31,7 +31,7 @@ def get_test_net(n_buses):
     line_indices = list(net.line.index) + list(net.line.index)
     pp.create_switches(net, line_buses, line_indices, "l")
     return net
-    
+
 def write_test_net_to_mongodb(net, project_name):
     ph = PandaHub()
     if ph.project_exists(project_name):
@@ -39,14 +39,14 @@ def write_test_net_to_mongodb(net, project_name):
         ph.delete_project(True)
     ph.create_project(project_name)
     ph.write_network_to_db(net, "test_net")
-    
+
 def load_test_subnet_from_mongodb(project_name):
     ph = PandaHub()
     ph.set_active_project(project_name)
     buses = list(range(1000))
     t0 = time.time()
-    subnet = ph.get_subnet_from_db("test_net", 
-                                 bus_filter={"index": {"$in": buses}})
+    subnet = ph.get_subnet_by_name("test_net",
+                                   bus_filter={"index": {"$in": buses}})
     t1 = time.time()
     print("LOADED NET IN %.2fs"%(t1-t0))
     return subnet
@@ -54,11 +54,11 @@ def load_test_subnet_from_mongodb(project_name):
 def profile_load_test(project_name):
     lp = LineProfiler()
     lp_wrapper = lp(load_test_subnet_from_mongodb)
-    lp.add_function(PandaHub.get_subnet_from_db_by_id)
+    lp.add_function(PandaHub.get_subnet)
     lp.add_function(PandaHub._add_element_from_collection)
     lp_wrapper(project_name)
     lp.print_stats()
-    
+
 if __name__ == '__main__':
     n_buses = 3e6 #3 Million buses
     project_name = "test_%u"%n_buses

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -50,7 +50,7 @@ def test_network_io(ph):
     # we check storing two different networks consecutively to ensure the nets are properly separated
     for net, name in [(net1, name1), (net2, name2)]:
         if ph.network_with_name_exists(name):
-            ph.delete_net_from_db(name)
+            ph.delete_network_by_name(name)
 
         assert ph.network_with_name_exists(name) == False
 
@@ -72,7 +72,7 @@ def test_network_io(ph):
         assert len(net3.load) == 0
 
     # delete first network
-    ph.delete_net_from_db(name1)
+    ph.delete_network_by_name(name1)
     assert ph.network_with_name_exists(name1) == False
 
     # check that second network is still in database

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -21,7 +21,7 @@ def test_additional_res_tables(ph):
     net1 = pp.create_empty_network()
     net1['res_test'] = pd.DataFrame(data={'col1': [1, 2], 'col2': [3, 4]})
     ph.write_network_to_db(net1, 'test')
-    net2 = ph.get_net_from_db('test')
+    net2 = ph.get_network_by_name('test')
 
     assert('res_test' in net2)
     assert(net1.res_test.shape == (2,2))
@@ -57,7 +57,7 @@ def test_network_io(ph):
         ph.write_network_to_db(net, name)
         assert ph.network_with_name_exists(name) == True
 
-        net_loaded = ph.get_net_from_db(name)
+        net_loaded = ph.get_network_by_name(name)
 
         pp.runpp(net)
         pp.runpp(net_loaded)
@@ -66,7 +66,7 @@ def test_network_io(ph):
         # doesn't compare to itself
         # assert pp.nets_equal(net, net_loaded, check_dtype=False)
 
-        net3 = ph.get_net_from_db(name, only_tables=["bus"])
+        net3 = ph.get_network_by_name(name, only_tables=["bus"])
         assert len(net3.bus) == len(net.bus)
         assert len(net3.line) == 0
         assert len(net3.load) == 0
@@ -77,7 +77,7 @@ def test_network_io(ph):
 
     # check that second network is still in database
     assert ph.network_with_name_exists(name2) == True
-    net2_loaded = ph.get_net_from_db(name2)
+    net2_loaded = ph.get_network_by_name(name2)
     pp.runpp(net2_loaded)
     assert pp.nets_equal(net2, net2_loaded, check_only_results=True)
 
@@ -90,20 +90,20 @@ def test_load_subnetwork(ph):
         net = nw_pp.mv_oberrhein()
         ph.write_network_to_db(net, name)
 
-    subnet = ph.get_subnet_from_db(name, bus_filter={"vn_kv": 110})
+    subnet = ph.get_subnet_by_name(name, bus_filter={"vn_kv": 110})
     expected_sizes = [("bus", 4), ("line", 0), ("trafo", 2), ("ext_grid", 2)]
 
     for element, size in expected_sizes:
         assert len(subnet[element]) == size
         assert len(subnet["res_" + element]) == size
 
-    subnet = ph.get_subnet_from_db(name, bus_filter={"vn_kv": 110},
+    subnet = ph.get_subnet_by_name(name, bus_filter={"vn_kv": 110},
                                    include_results=False)
     for element, size in expected_sizes:
         assert len(subnet[element]) == size
         assert len(subnet["res_" + element]) == 0
 
-    subnet = ph.get_subnet_from_db(name, bus_filter={"vn_kv": 110},
+    subnet = ph.get_subnet_by_name(name, bus_filter={"vn_kv": 110},
                                    add_edge_branches=False)
     expected_sizes = [("bus", 2), ("line", 0), ("trafo", 0), ("ext_grid", 2)]
 
@@ -135,7 +135,7 @@ def test_access_and_set_single_values(ph):
     ph.delete_element(name, element, index)
     with pytest.raises(PandaHubError):
         ph.get_net_value_from_db(name, element, index, parameter)
-    net = ph.get_net_from_db(name)
+    net = ph.get_network_by_name(name)
     assert index not in net[element].index
 
 
@@ -143,7 +143,7 @@ def test_pandapipes(ph):
     ph.set_active_project('pytest')
     net = nw_pps.gas_versatility()
     ph.write_network_to_db(net, 'versatility')
-    net2 = ph.get_net_from_db('versatility', convert=False)
+    net2 = ph.get_network_by_name('versatility', convert=False)
     pps.pipeflow(net)
     pps.pipeflow(net2)
     assert nets_equal(net, net2, check_only_results=True)
@@ -167,7 +167,7 @@ if __name__ == '__main__':
     ph.create_project('pytest')
     net = nw_pps.gas_versatility()
     ph.write_network_to_db(net, 'versatility')
-    net2 = ph.get_net_from_db('versatility')
+    net2 = ph.get_network_by_name('versatility')
     pps.pipeflow(net)
     pps.pipeflow(net2)
     # test_network_io(ph)

--- a/test/test_projects.py
+++ b/test/test_projects.py
@@ -53,7 +53,7 @@ def test_upgrade_project():
                 raise pandahub.PandaHubError("net must be a pandapower or pandapipes object")
             if self._network_with_name_exists(name, db):
                 if overwrite:
-                    self.delete_net_from_db(name)
+                    self.delete_network_by_name(name)
                 else:
                     raise pandahub.PandaHubError("Network name already exists")
             max_id_network = db["_networks"].find_one(sort=[("_id", -1)])

--- a/test/test_projects.py
+++ b/test/test_projects.py
@@ -92,7 +92,7 @@ def test_upgrade_project():
     ph.set_active_project("pytest")
     ph.upgrade_project_to_latest_version()
     # and test if everything went fine
-    net2 = ph.get_net_from_db("simple_network")
+    net2 = ph.get_network_by_name("simple_network")
     assert pp.nets_equal(net, net2, check_dtype=False)
 
 


### PR DESCRIPTION
Make net_id the only unique identifier in a project's network collection, ensure consistent handling when specifying networks by their name or net_id, and fix a race condition when automatically assigning an index on network insertion. 

Inserting multiple networks with the same name is not considered an error anymore. Only the assigned net_id, which is saved in the network document on the `_id` field, is considered unique. 

Various functions operating on a single network exist which identify the network by it's name. As this can be ambiguous, alternative functions which identify the network by net_id exist. Using the latter is recommended. The former still work but will throw an exception if multiple networks for the given name exist in the database.

The function which stores networks, `write_net_to_db`, can optionally be passed a custom value for `net_id`. This does not have to be an integer, but an incrementing integer is assigned as `net_id` if no value is passed.

All functions affected by this change print out deprecation warnings with recommendations for replacements.

### Possible breaking changes

A special handling of net_id in CRUD functions has been removed. Previously, these functions internally interpreted a passed net_id as the name of a network if it was of type string. This prohibits directly using strings as net_ids.

Function arguments specifying the net_id have sometimes been named `net`, these are now consistently named `net_id` to avoid confusion.
