### PR TITLE
add mongodb client getter function

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -23,12 +23,14 @@ import pandapipes as pps
 from pandapipes import from_json_string as from_json_pps, FromSerializableRegistryPpipe
 import pandapower as pp
 import pandapower.io_utils as io_pp
+
 from pandahub.api.internal.settings import MONGODB_URL, MONGODB_USER, MONGODB_PASSWORD, MONGODB_GLOBAL_DATABASE_URL, \
     MONGODB_GLOBAL_DATABASE_USER, MONGODB_GLOBAL_DATABASE_PASSWORD, CREATE_INDEXES_WITH_PROJECT
 from pandahub.lib.database_toolbox import (
     create_timeseries_document,
     convert_timeseries_to_subdocuments,
     convert_element_to_dict,
+    get_mongo_client,
     json_to_object,
     serialize_object_data,
     get_dtypes,
@@ -94,19 +96,9 @@ class PandaHub:
         mongodb_indexes=MONGODB_INDEXES,
         elements_without_vars = None,
     ):
-        mongo_client_args = {
-            "host": connection_url,
-            "uuidRepresentation": "standard",
-            "connect": False,
-        }
-        if connection_user:
-            mongo_client_args |= {
-                "username": connection_user,
-                "password": connection_password,
-            }
         self._datatypes = datatypes
         self.mongodb_indexes = mongodb_indexes
-        self.mongo_client = MongoClient(**mongo_client_args)
+        self.mongo_client = get_mongo_client(connection_url, connection_user, connection_password)
         self.mongo_client_global_db = None
         self.active_project = None
         self.user_id = user_id

--- a/pandahub/lib/database_toolbox.py
+++ b/pandahub/lib/database_toolbox.py
@@ -3,6 +3,9 @@ from typing import Optional
 
 import numpy as np
 import pandas as pd
+from pymongo import MongoClient
+
+from pandahub.api.internal.settings import MONGODB_URL, MONGODB_USER, MONGODB_PASSWORD
 from pandahub.lib.datatypes import DATATYPES
 import base64
 import hashlib
@@ -421,3 +424,17 @@ def migrate_userdb_to_beanie(ph):
                  {'$unset': 'id'},
                  {'$out': 'users'}]
     userdb.aggregate(migration)
+
+def get_mongo_client(connection_url=MONGODB_URL, connection_user=MONGODB_USER,
+                     connection_password=MONGODB_PASSWORD) -> MongoClient:
+    mongo_client_args = {
+        "host": connection_url,
+        "uuidRepresentation": "standard",
+        "connect": False,
+    }
+    if connection_user:
+        mongo_client_args |= {
+            "username": connection_user,
+            "password": connection_password,
+        }
+    return MongoClient(**mongo_client_args)


### PR DESCRIPTION
Add `get_mongo_client()` helper function returning a MongoClient instance with the same connection URI logic as in PandaHub. Can be used to get a database connection without  having to create a PandaHub instance.