### PR TITLE
make auth transport configurable (token or cookie)

### DIFF
--- a/pandahub/api/internal/settings.py
+++ b/pandahub/api/internal/settings.py
@@ -51,6 +51,7 @@ SECRET = get_secret("SECRET")
 
 REGISTRATION_ENABLED = settings_bool("REGISTRATION_ENABLED", default=True)
 REGISTRATION_ADMIN_APPROVAL = settings_bool("REGISTRATION_ADMIN_APPROVAL", default=False)
+AUTH_TRANSPORT=get_os_env("AUTH_TRANSPORT", "bearer").lower()
 
 CREATE_INDEXES_WITH_PROJECT = settings_bool("CREATE_INDEXES_WITH_PROJECT", default=True)
 


### PR DESCRIPTION
AUTH_TRANSPORT can be "bearer" or "cookie". 
No functional change with the default value "bearer"  (-> token in header).
[CookieTransport](https://fastapi-users.github.io/fastapi-users/latest/configuration/authentication/transports/cookie/) is used when setting the value  to "cookie". 