### PR TITLE
allow activating locked project if not held by other user

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -438,10 +438,11 @@ class PandaHub:
         user = self._get_user()
         if not user["is_superuser"] and self.user_id not in project_doc["users"].keys():
             raise PandaHubError("You don't have rights to access this project", 403)
-        elif project_doc.get("locked") and project_doc.get("locked_by") != self.user_id:
-            raise PandaHubError("Project is locked by another user")
-        else:
-            return project_doc
+        if project_doc.get("locked"):
+            locked_by = project_doc.get("locked_by")
+            if locked_by is not None and locked_by != self.user_id:
+                raise PandaHubError("Project is locked by another user")
+        return project_doc
 
     def _get_project_database(self) -> Database:
         return self.get_project_database()


### PR DESCRIPTION
ph.get_project_document() is supposed to throw an exception if the project is locked by another user. This was also true if the project was locked for some other reason but no user had a lock on it. 

Now, the exception is only thrown if `locked_by` is also set.