### PR TITLE
set default permissions of None in get_projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.5.5
+🐛 Bug Fixes
+* default project["permissions"] to None in get_projects instead of omitting it (https://github.com/e2nIEE/pandahub/pull/117)
+
 ## 0.5.4
 
 🛠 Improvements

--- a/pandahub/__init__.py
+++ b/pandahub/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 from pandahub.lib.PandaHub import PandaHub, PandaHubError, PandaPowerNet, PandaPipesNet, PandaNet, SettingsValue, ProjectID
 

--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -331,9 +331,11 @@ class PandaHub:
         for project in projects:
             if "_id" in project:
                 project["id"] = str(project.pop("_id"))
-            if self.user_id:
-                role = project.get("users").get(self.user_id)
+            if self.user_id and "users" in project:
+                role = project["users"].get(self.user_id)
                 project["permissions"] = self.get_permissions_by_role(role)
+            else:
+                project["permissions"] = None
         return projects
 
     def get_project_names(self) -> list[str]:


### PR DESCRIPTION
Fix an exception when "users" was excluded by the projection in get_projects and restore the previous behavior of setting the "permission" key in the projects directory to None instead of omitting it.