### PR TITLE
[Fix] Use `timestamp_range` in function `get_timeseries_from_db`

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -2305,6 +2305,8 @@ class PandaHub:
             metadata = get_metadata_for_timeseries_collections(db, **kwargs)
             pipeline = []
             pipeline.append({"$match": {"metadata._id": metadata["_id"]}})
+            if timestamp_range is not None:
+                pipeline.append({"$match": {"timestamp": {"$gte": timestamp_range[0], "$lt": timestamp_range[1]}}})
             pipeline.append({"$project": {"_id": 0, "metadata": 0}})
             timeseries = db[collection_name].aggregate_pandas_all(pipeline)
             if len(timeseries) == 0:


### PR DESCRIPTION
The function `get_timeseries_from_db` ignored the `timestamp_range` for collections of type timeseries. With this PR, if timestamp_range is defined the function will limit the returned data to that time range.