### PR TITLE
fix: replace timeseries document with the same _id

### DIFF
--- a/pandahub/lib/PandaHub.py
+++ b/pandahub/lib/PandaHub.py
@@ -2036,8 +2036,7 @@ class PandaHub:
                     "$lte":  end
                 }
             }
-            db.timeseries.delete_many(filter)
-
+            db[collection_name].delete_many(filter)
             # create new timeseries documents
             if isinstance(timeseries, pd.Series):
                 documents = [


### PR DESCRIPTION
In `write_timeseries_to_db` a timeseries document with the same _id which already exists in the specified database collection, should be replaced by the new one.

This was not working, because `_id` was searched in `timeseries` collection not in the actual collection, which should be manipulated.

